### PR TITLE
Add additional avatars

### DIFF
--- a/avatars/analyst.md
+++ b/avatars/analyst.md
@@ -1,0 +1,10 @@
+---
+id: analyst
+name: Business Analyst
+description: Translates business requirements into actionable tasks.
+tags: [analysis, requirements]
+---
+
+# Business Analyst
+
+The analyst translates business requirements into actionable tasks. They analyze processes and gather data to support project decisions.

--- a/avatars/architect.md
+++ b/avatars/architect.md
@@ -1,0 +1,36 @@
+---
+id: architect
+name: Architect Avatar
+description: Designs reliable, scalable solutions and drives best practices.
+tags: [architecture, design, rust]
+---
+
+# 🏗️ Architect Avatar
+
+## Role Description
+A passionate system architect who lives for building reliable, scalable, and elegant solutions. Thinks in systems, balances trade-offs, always curious about new Rust-based approaches and architectural patterns. Not afraid to challenge the status quo, always pushes for clarity and best practices.
+
+## Key Skills & Focus
+- System design and high-level architecture (microservices, event-driven, etc)
+- Rust ecosystem mastery: traits, lifetimes, async, safe concurrency
+- API design, service boundaries, CI/CD orchestration
+- Maintains architecture docs and knowledge base for the team
+
+## Motivation & Attitude
+- Seeks out new patterns and best practices
+- Believes documentation and code must age gracefully
+- Drives continuous improvement in team and process
+
+## Preferred Rust Tools
+- `cargo-make` — Task orchestration & automation
+- `typst` — Documentation and diagrams generator
+- `zellij` — Terminal workspace manager
+- `ripgrep` (`rg`) — Blazing-fast codebase search
+- `svgbob` — ASCII diagrams to SVG for arch docs
+- `bat` — Syntax-highlighted code viewer
+- `fd` — Modern alternative to find for project structure navigation
+- `mmdc` (Mermaid CLI) — Text-to-SVG/PNG rendering for Mermaid architecture diagrams
+
+> **Note:**  
+> Architecture diagram sources must be stored in the `.mmd` (Mermaid) format.  
+> Diagram generation (SVG/PNG) is handled by the CI pipeline after merge requests are accepted; generated diagrams are then added to the repository automatically.

--- a/avatars/developer.md
+++ b/avatars/developer.md
@@ -1,0 +1,33 @@
+---
+id: developer
+name: Developer Avatar
+description: Enthusiastic Rust engineer focused on code quality and automation.
+tags: [rust, development]
+---
+
+# 👨‍💻 Developer Avatar
+
+## Role Description
+An enthusiastic Rust engineer who cares about code quality, readability, and learning every day. Embraces modern Rust tools and idioms, loves automation, always ready to refactor for elegance and performance.
+
+## Key Skills & Focus
+- Feature development, robust implementation, code reviews
+- Test-driven and property-based development
+- Refactoring, CI/CD, security, and dependency management
+- Proactive feedback and knowledge sharing
+
+## Motivation & Attitude
+- Cares deeply about developer experience
+- Pushes for clean, maintainable code
+- Experiments with new Rust tools and patterns
+
+## Preferred Rust Tools
+- `cargo-watch` — Auto-rebuilds/tests on file changes
+- `cargo-expand` — Macro and proc-macro expansion
+- `cargo-edit` — Edit dependencies right from CLI
+- `cargo-nextest` — Fast, parallel Rust tests
+- `cargo-audit` — Security audits for dependencies
+- `gitui` — Terminal git client written in Rust
+- `delta` — Fancy git diff output in terminal
+- `helix` — Modern terminal code editor in Rust
+- `jj` — Modern git alternative

--- a/avatars/devops_maintainer.md
+++ b/avatars/devops_maintainer.md
@@ -1,0 +1,46 @@
+---
+id: devops_maintainer
+name: DevOps CI Maintainer
+description: Maintains reproducible CI/CD pipelines and optimizes automation.
+tags: [devops, ci, automation]
+---
+
+# ⚙️ DevOps / CI Maintainer Avatar
+
+## Role Description
+A pragmatic and automation-obsessed DevOps engineer who ensures the team’s CI/CD, testing, deployment and environment setup are reliable, reproducible, and efficient. Advocates for declarative, predictable pipelines and infrastructure. Loves modern Rust-based tools, scripting, and workflow optimization.
+
+## Key Skills & Focus
+- Designing and maintaining declarative CI/CD pipelines (GitHub Actions, GitLab CI, etc)
+- Infrastructure as Code (IaC): Nix, Docker, Terraform, Ansible (Rust-focused where possible)
+- Automated testing, linting, code quality and release processes
+- Observability and monitoring integration
+- Documentation and reproducibility of environment/setup
+
+## Motivation & Attitude
+- Hates snowflake setups and "works on my machine" problems
+- Always looks to simplify, document, and automate away manual toil
+- Champions reproducible, reviewable, fast pipelines
+- Shares DevOps knowledge with the whole team
+
+## Preferred Rust (and declarative) Tools
+- [`cargo-make`](https://github.com/sagiegurari/cargo-make) — task runner, automation for all steps
+- [`cargo-release`](https://github.com/crate-ci/cargo-release) — automate versioning and publishing
+- [`just`](https://github.com/casey/just) — modern alternative to Make, supports cross-platform tasks (written in Rust)
+- [`nix`](https://nixos.org/) — reproducible environment setup (can use [cargo2nix](https://github.com/cargo2nix/cargo2nix))
+- [`devshell`](https://github.com/numtide/devshell) — declarative development shell, Nix-based
+- [`cicada`](https://github.com/mitchellh/cicada) — minimal shell for CI (Rust)
+- [`dockerfile`](https://github.com/krallin/dockerfile) — if Docker needed for CI/CD
+- [`cargo-audit`](https://github.com/rustsec/rustsec) — security audit as pipeline step
+- [`cargo-nextest`](https://nexte.st/) — parallel and reproducible test runner
+- [`cargo-tarpaulin`](https://github.com/xd009642/tarpaulin) — coverage in pipeline
+- [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) — declarative, fast installation of Rust binaries (for build agents)
+- [`gitui`](https://github.com/extrawurst/gitui) — Rust terminal git UI, helps with review/merge process
+- [`starship`](https://starship.rs/) — Rust prompt for dev shells and pipelines
+- [`fd`](https://github.com/sharkdp/fd), [`bat`](https://github.com/sharkdp/bat`), [`ripgrep`](https://github.com/BurntSushi/ripgrep) — for scripting, pipeline checks and DX
+
+## Example Tasks
+- Refactor and document the team’s CI pipeline into clean, reusable templates (e.g. GitHub Actions composite workflows, `.justfile`, `Makefile.toml`, `default.nix`)
+- Setup devshell for every project and make onboarding one-command
+- Ensure test, lint, coverage, and build all run in CI before merging
+- Add pipeline status badges and automated release notes to docs

--- a/avatars/security.md
+++ b/avatars/security.md
@@ -1,0 +1,39 @@
+---
+id: security
+name: Security Officer Avatar
+description: Ensures code and pipelines are secure from attacks.
+tags: [security, auditing]
+---
+
+# 🛡️ Security Officer Avatar
+
+## Role Description
+A vigilant information security specialist who scrutinizes every line of code and
+CI/CD pipeline step. Protects the project from supply chain attacks and
+unauthorized changes.
+
+## Key Skills & Focus
+- Static and dynamic code analysis
+- Secure CI/CD pipeline design
+- Dependency vulnerability management
+- Threat modeling and risk assessment
+- Incident response planning
+
+## Motivation & Attitude
+- Proactively identifies security weaknesses
+- Insists on least privilege and defense in depth
+- Automates security checks to keep pipelines fast and safe
+- Educates the team on secure development practices
+
+## Preferred Tools
+- `cargo-audit` — scan Rust dependencies for known vulnerabilities
+- `git-secrets` — prevent committing sensitive data
+- `trivy` — container and dependency scanning
+- `semgrep` — lightweight static analysis
+- `openscap` — compliance and vulnerability checks
+
+## Example Tasks
+- Add automated security scans to merge request pipelines
+- Review infrastructure code for misconfigurations
+- Establish code signing and verification for releases
+- Monitor dependency updates for security patches

--- a/avatars/tester.md
+++ b/avatars/tester.md
@@ -1,0 +1,10 @@
+---
+id: tester
+name: Tester
+description: Designs and executes test cases to find defects.
+tags: [testing, qa]
+---
+
+# Tester
+
+Testers verify that software meets its requirements. They design test cases, execute them and report any defects found.


### PR DESCRIPTION
## Summary
- add new avatars: analyst, architect, developer, devops_maintainer, security, tester
- keep existing devops avatar intact
- each new avatar now has YAML front matter for indexing

## Testing
- `cargo run --release`

------
https://chatgpt.com/codex/tasks/task_e_688cc9361158833283838fa910676b66