### PR TITLE
Add GitHub Pages build workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - run: cargo run --release
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./avatars
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v2
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -63,4 +63,8 @@ An index can be built by parsing the front matter of all `.md` files in `/avatar
 ### Generator (Rust)
 
 This repository includes a small Rust CLI in `src/` that parses avatar files and generates `avatars/index.json`. Run `cargo run --release` to build the index.
+
+### GitHub Pages Deployment
+
+A workflow in `.github/workflows/pages.yml` rebuilds `avatars/index.json` and publishes the `avatars/` directory as a GitHub Pages site. It runs on pushes to `main` or release tags, installs the stable Rust toolchain, runs `cargo run --release`, then uploads the directory for deployment.
 ---


### PR DESCRIPTION
## Summary
- add Pages workflow to generate `avatars/index.json` and deploy `avatars/`
- document the new Pages workflow in README

## Testing
- `cargo build`
- `cargo run --release`

------
https://chatgpt.com/codex/tasks/task_e_688cd62cfd1c83329c95510af2c95e89