### PR TITLE
docs: add MCP server section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,36 @@ An index can be built by parsing the front matter of all `.md` files in `/avatar
 - **Get full avatar:** GET `/avatars/{id}.md`
 - **Get generated index:** GET `/avatars/index.json` (optional)
 
+### MCP Server
+
+An optional Model Context Protocol (MCP) server exposes the same avatar data over
+STDIO.
+
+Run it with:
+
+```
+cargo run --bin server
+```
+
+The server implements the following methods:
+
+- `resources/list` – list all available avatars.
+- `resources/read` – read the Markdown for a specific avatar.
+
+Example configuration for an MCP client:
+
+```json
+{
+  "mcpServers": [
+    {
+      "name": "avatars",
+      "command": "cargo",
+      "args": ["run", "--bin", "server"]
+    }
+  ]
+}
+```
+
 ### Generator (Rust)
 
 This repository includes a small Rust CLI in `src/` that parses avatar files and generates `avatars/index.json`. Run `cargo run --release` to build the index.

--- a/specification.md
+++ b/specification.md
@@ -90,6 +90,12 @@ You are a DevOps engineer. Your job is to:
 * (Optionally) **Get generated index:**
   GET `/avatars/index.json` (if generator is used)
 
+An MCP server exposes the same data via the Model Context Protocol. It
+supports the following protocol messages:
+
+- `resources/list` – list all available avatars.
+- `resources/read` – read the content of an avatar.
+
 ---
 
 ## 7. Machine and human readable


### PR DESCRIPTION
## Summary
- document MCP server usage, methods, and sample client configuration
- note in specification that MCP server mirrors static API and list protocol messages

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688e1324b5608332917bcba563affeb5