### PR TITLE
Add stdio JSON-RPC MCP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,11 @@ name = "avatars_generator"
 version = "0.1.0"
 dependencies = [
  "leptos",
+ "rust-mcp-schema",
  "serde",
  "serde_json",
  "serde_yaml",
+ "tokio",
  "walkdir",
 ]
 
@@ -1290,6 +1292,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-mcp-schema"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e71aee61257cd3d4a78fdc10c92c29e7a55c4f767119ffdafd837bb5e5cb9a"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,6 +1475,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,10 +1633,24 @@ dependencies = [
  "io-uring",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
  "socket2 0.6.0",
+ "tokio-macros",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,9 @@ serde_yaml = "0.9"
 serde_json = "1.0"
 walkdir = "2"
 leptos = { version = "0.5", optional = true }
+tokio = { version = "1", features = ["full"] }
+rust-mcp-schema = "0.7"
+
+[[bin]]
+name = "mcp_server"
+path = "src/server.rs"

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,86 @@
+use serde_json::{json, Value};
+use std::fs;
+use std::path::Path;
+use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+async fn handle_initialize() -> Value {
+    json!({
+        "serverInfo": {"name": "Avatars MCP", "version": "0.1"},
+        "capabilities": {"resources": true}
+    })
+}
+
+fn list_avatar_files() -> Vec<String> {
+    let avatars_dir = Path::new("avatars");
+    let mut files = Vec::new();
+    if let Ok(entries) = fs::read_dir(avatars_dir) {
+        for entry in entries.flatten() {
+            if entry.path().extension().and_then(|s| s.to_str()) == Some("md") {
+                files.push(entry.path().to_string_lossy().to_string());
+            }
+        }
+    }
+    files
+}
+
+async fn handle_resources_list() -> Value {
+    let resources: Vec<Value> = list_avatar_files()
+        .into_iter()
+        .map(|uri| json!({"uri": uri}))
+        .collect();
+    json!({"resources": resources})
+}
+
+async fn handle_resources_read(uri: &str) -> Value {
+    match fs::read_to_string(uri) {
+        Ok(content) => json!({"contents": content}),
+        Err(e) => json!({"error": {"code": -32000, "message": e.to_string()}}),
+    }
+}
+
+#[tokio::main]
+async fn main() -> io::Result<()> {
+    let stdin = BufReader::new(io::stdin());
+    let mut lines = stdin.lines();
+    let mut stdout = io::stdout();
+
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let req: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(e) => {
+                let err = json!({"jsonrpc":"2.0","error":{"code":-32700,"message":e.to_string()}});
+                stdout.write_all(err.to_string().as_bytes()).await?;
+                stdout.write_all(b"\n").await?;
+                continue;
+            }
+        };
+        let id = req.get("id").cloned().unwrap_or(Value::Null);
+        let method = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
+
+        let result = match method {
+            "initialize" => handle_initialize().await,
+            "resources/list" => handle_resources_list().await,
+            "resources/read" => {
+                if let Some(uri) = req.get("params").and_then(|p| p.get("uri")).and_then(|u| u.as_str()) {
+                    handle_resources_read(uri).await
+                } else {
+                    json!({"error": {"code": -32602, "message": "Missing uri"}})
+                }
+            }
+            _ => json!({"error": {"code": -32601, "message": "Unknown method"}}),
+        };
+
+        let response = if result.get("error").is_some() {
+            json!({"jsonrpc": "2.0", "id": id, "error": result["error"]})
+        } else {
+            json!({"jsonrpc": "2.0", "id": id, "result": result})
+        };
+        stdout.write_all(response.to_string().as_bytes()).await?;
+        stdout.write_all(b"\n").await?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement Tokio-based JSON-RPC server exposing `initialize`, `resources/list`, and `resources/read`
- traverse `avatars/` to list and read markdown resources
- add dependencies and bin entry for running the server as `mcp_server`

## Testing
- `cargo build`
- `echo '{"jsonrpc":"2.0","id":1,"method":"initialize"}' | cargo run --quiet --bin mcp_server`
- `echo '{"jsonrpc":"2.0","id":2,"method":"resources/list"}' | cargo run --quiet --bin mcp_server`
- `echo '{"jsonrpc":"2.0","id":3,"method":"resources/read","params":{"uri":"avatars/analyst.md"}}' | cargo run --quiet --bin mcp_server`


------
https://chatgpt.com/codex/tasks/task_e_688e132133748332931d0895c2dd1be8