### PR TITLE
Fix Pages workflow path and update API documentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,10 +25,13 @@ jobs:
           toolchain: stable
           override: true
       - run: cargo run --release
+      - run: |
+          mkdir -p public/avatars
+          cp -r avatars/* public/avatars/
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: ./avatars
+          path: ./public
 
   deploy:
     needs: build

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ This repository includes a small Rust CLI in `src/` that parses avatar files and
 
 ### GitHub Pages Deployment
 
-A workflow in `.github/workflows/pages.yml` rebuilds `avatars/index.json` and publishes the `avatars/` directory as a GitHub Pages site. It runs on pushes to `main` or release tags, installs the stable Rust toolchain, runs `cargo run --release`, then uploads the directory for deployment.
+ A workflow in `.github/workflows/pages.yml` rebuilds `avatars/index.json` and publishes it under the `avatars/` path on GitHub Pages. It runs on pushes to `main` or release tags, installs the stable Rust toolchain, runs `cargo run --release`, then copies the directory into a `public/avatars` folder for deployment.
 ---
 
 ### GitHub Pages Workflow
@@ -109,10 +109,14 @@ A workflow in `.github/workflows/pages.yml` rebuilds `avatars/index.json` and pu
 The latest version of the avatar API is served from GitHub Pages at:
 
 ```
-https://<github-user>.github.io/avatars-mcp/
+https://qqrm.github.io/avatars-mcp/
 ```
 
-You can browse individual avatar files or fetch `avatars/index.json` from that URL.
+You can browse individual avatar files or fetch `avatars/index.json` from that URL, for example:
+
+```
+https://qqrm.github.io/avatars-mcp/avatars/index.json
+```
 
 ### Release Versioning
 


### PR DESCRIPTION
## Summary
- publish avatars under `public/avatars` so Pages serves `avatars/index.json`
- document GitHub Pages URL for avatar API

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892b4524dc08332bd8006f6d70b085f