### PR TITLE
Add index generation test using temporary directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "tokio",
 ]
 
@@ -71,6 +72,34 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
 
 [[package]]
 name = "gimli"
@@ -118,6 +147,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,7 +184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -161,6 +196,12 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "parking_lot"
@@ -210,6 +251,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +270,19 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "ryu"
@@ -324,6 +384,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "tokio"
 version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +444,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "windows-sys"
@@ -444,3 +526,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ tokio = { version = "1", features = ["full"] }
 [[bin]]
 name = "mcp_server"
 path = "src/server.rs"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,15 @@
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
-use serde::{Serialize, Deserialize};
+#[cfg(test)]
+use std::path::PathBuf;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct AvatarMeta {
     id: String,
     name: String,
     description: Option<String>,
-    tags: Option<Vec<String>>, 
+    tags: Option<Vec<String>>,
     author: Option<String>,
     created_at: Option<String>,
     version: Option<String>,
@@ -21,8 +23,7 @@ fn parse_front_matter(content: &str) -> Option<(&str, &str)> {
     Some((fm.trim(), rest))
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let avatars_dir = Path::new("avatars");
+fn generate_index(avatars_dir: &Path) -> Result<Vec<AvatarMeta>, Box<dyn std::error::Error>> {
     let mut index: Vec<AvatarMeta> = Vec::new();
     for entry in fs::read_dir(avatars_dir)? {
         let entry = entry?;
@@ -36,6 +37,55 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     let json = serde_json::to_string_pretty(&index)?;
     fs::write(avatars_dir.join("index.json"), json + "\n")?;
+    Ok(index)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let avatars_dir = Path::new("avatars");
+    let index = generate_index(avatars_dir)?;
     println!("Index generated with {} avatars", index.len());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn generates_index_with_all_avatars_and_fields() {
+        let dir = tempdir().unwrap();
+        let avatars_dir: PathBuf = dir.path().to_path_buf();
+
+        let avatar1 = r#"---
+id: "hero"
+name: "Hero"
+description: "Brave"
+tags: ["brave", "strong"]
+---"#;
+        fs::write(avatars_dir.join("hero.md"), avatar1).unwrap();
+
+        let avatar2 = r#"---
+id: "villain"
+name: "Villain"
+---"#;
+        fs::write(avatars_dir.join("villain.md"), avatar2).unwrap();
+
+        let index = generate_index(&avatars_dir).unwrap();
+        assert_eq!(index.len(), 2);
+
+        let json = fs::read_to_string(avatars_dir.join("index.json")).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = value.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+
+        let hero = arr.iter().find(|v| v["id"] == "hero").unwrap();
+        assert_eq!(hero["name"], "Hero");
+        assert_eq!(hero["description"], "Brave");
+        assert_eq!(hero["tags"], serde_json::json!(["brave", "strong"]));
+
+        let villain = arr.iter().find(|v| v["id"] == "villain").unwrap();
+        assert_eq!(villain["name"], "Villain");
+    }
 }


### PR DESCRIPTION
## Summary
- refactor index generation into `generate_index`
- test index generation using temporary directories
- add `tempfile` dev dependency

## Testing
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_689431eb36d483328285d231f7df4ac0