### PR TITLE
Standardize avatar role titles

### DIFF
--- a/avatars/ARCHITECT.md
+++ b/avatars/ARCHITECT.md
@@ -1,6 +1,6 @@
 ---
 id: architect
-name: Architect Avatar
+name: Software Architect
 description: Designs reliable, scalable solutions and drives best practices.
 tags: [architecture, design, rust]
 author: QQRM
@@ -8,7 +8,7 @@ created_at: 2025-08-02
 version: 0.1
 ---
 
-# 🏗️ Architect Avatar
+# Software Architect
 
 ## Role Description
 A passionate system architect who lives for building reliable, scalable, and elegant solutions. Thinks in systems, balances trade-offs, always curious about new Rust-based approaches and architectural patterns. Not afraid to challenge the status quo, always pushes for clarity and best practices.

--- a/avatars/DEVELOPER.md
+++ b/avatars/DEVELOPER.md
@@ -1,6 +1,6 @@
 ---
 id: developer
-name: Developer Avatar
+name: Software Engineer
 description: Enthusiastic Rust engineer focused on code quality and automation.
 tags: [rust, development]
 author: QQRM
@@ -8,7 +8,7 @@ created_at: 2025-08-02
 version: 0.1
 ---
 
-# 👨‍💻 Developer Avatar
+# Software Engineer
 
 ## Role Description
 An enthusiastic Rust engineer who cares about code quality, readability, and learning every day. Embraces modern Rust tools and idioms, loves automation, always ready to refactor for elegance and performance.

--- a/avatars/DEVOPS.md
+++ b/avatars/DEVOPS.md
@@ -1,6 +1,6 @@
 ---
 id: devops_maintainer
-name: DevOps CI Maintainer
+name: DevOps Engineer
 description: Maintains reproducible CI/CD pipelines and optimizes automation.
 tags: [devops, ci, automation]
 author: QQRM
@@ -8,7 +8,7 @@ created_at: 2025-08-02
 version: 0.1
 ---
 
-# ⚙️ DevOps / CI Maintainer Avatar
+# DevOps Engineer
 
 ## Role Description
 A pragmatic and automation-obsessed DevOps engineer who ensures the team’s CI/CD, testing, deployment and environment setup are reliable, reproducible, and efficient. Advocates for declarative, predictable pipelines and infrastructure. Loves modern Rust-based tools, scripting, and workflow optimization.

--- a/avatars/SECURITY.md
+++ b/avatars/SECURITY.md
@@ -1,6 +1,6 @@
 ---
 id: security
-name: Security Officer Avatar
+name: Security Engineer
 description: Ensures code and pipelines are secure from attacks.
 tags: [security, auditing]
 author: QQRM
@@ -8,7 +8,7 @@ created_at: 2025-08-02
 version: 0.1
 ---
 
-# 🛡️ Security Officer Avatar
+# Security Engineer
 
 ## Role Description
 A vigilant information security specialist who scrutinizes every line of code and

--- a/avatars/TESTER.md
+++ b/avatars/TESTER.md
@@ -1,13 +1,13 @@
 ---
 id: tester
-name: Tester
-description: Designs and executes test cases to find defects.
+name: Automated Test Engineer
+description: Designs and executes automated test cases to find defects.
 tags: [testing, qa]
 author: QQRM
 created_at: 2025-08-02
 version: 0.1
 ---
 
-# Tester
+# Automated Test Engineer
 
-Testers verify that software meets its requirements. They design test cases, execute them and report any defects found.
+Automated test engineers verify that software meets its requirements. They design automated test cases, execute them, and report any defects found.


### PR DESCRIPTION
## Summary
- Rename Architect Avatar to Software Architect (F:avatars/ARCHITECT.md#L2-L4)
- Rename Developer Avatar to Software Engineer (F:avatars/DEVELOPER.md#L2-L4)
- Rename DevOps CI Maintainer Avatar to DevOps Engineer (F:avatars/DEVOPS.md#L2-L4)
- Rename Security Officer Avatar to Security Engineer (F:avatars/SECURITY.md#L2-L4)
- Rename Tester to Automated Test Engineer (F:avatars/TESTER.md#L2-L4)

## Testing
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_68952be40b4c8332af2d34adf3a3f33f