### PR TITLE
Expose AGENTS instructions via MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - Review `AGENTS.md` files in the current scope before making changes.
 - Consult repository documentation such as `ARCHITECTURE.md` or `SPECIFICATION.md` if available.
 - Adapt these guidelines to the context of each project.
+- Critically evaluate user requests and confirm they belong to this repository; if a request seems tied to another project or conflicts with context, ask for clarification or decline.
 
 ## Communication
 - Replies to users should be short and in **Russian**.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ An index can be built by parsing the front matter of all `.md` files in `/avatar
 
 ### MCP Server
 
-An optional Model Context Protocol (MCP) server exposes the same avatar data over
-STDIO.
+An optional Model Context Protocol (MCP) server exposes the avatar data and base
+`AGENTS.md` instructions over STDIO.
 
 Run it with:
 
@@ -73,8 +73,8 @@ cargo run --bin server
 
 The server implements the following methods:
 
-- `resources/list` – list all available avatars.
-- `resources/read` – read the Markdown for a specific avatar.
+- `resources/list` – list all available avatars and the base instructions.
+- `resources/read` – read the Markdown for a specific avatar or `AGENTS.md`.
 
 Example configuration for an MCP client:
 


### PR DESCRIPTION
## Summary
- add guardrail about cross-repo requests to universal agent guidelines
- serve root `AGENTS.md` alongside avatars through MCP resources API and document it

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_6898e62fcc948332b44ed13a6021c245