### PR TITLE
Serve BASE_AGENTS.md for client instructions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,6 +29,7 @@ jobs:
       - run: |
           mkdir -p public/avatars
           cp -r avatars/* public/avatars/
+          cp BASE_AGENTS.md public/
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/BASE_AGENTS.md
+++ b/BASE_AGENTS.md
@@ -1,0 +1,9 @@
+# Base Agent Instructions
+
+Use these avatars to guide agent behavior.
+
+- Each file in `avatars/` describes a distinct persona.
+- Choose the avatar that matches your task.
+- Provide the avatar text as part of the system prompt.
+- Keep interactions consistent with the selected persona.
+

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ An index can be built by parsing the front matter of all `.md` files in `/avatar
 ### MCP Server
 
 An optional Model Context Protocol (MCP) server exposes the avatar data and base
-`AGENTS.md` instructions over STDIO.
+`BASE_AGENTS.md` instructions over STDIO.
 
 Run it with:
 
@@ -83,7 +83,7 @@ cargo run --bin mcp_server
 The server implements the following methods:
 
 - `resources/list` – list all available avatars and the base instructions.
-- `resources/read` – read the Markdown for a specific avatar or `AGENTS.md`.
+- `resources/read` – read the Markdown for a specific avatar or `BASE_AGENTS.md`.
 
 Example configuration for an MCP client:
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -34,7 +34,7 @@ fn list_avatar_files() -> std::io::Result<Vec<String>> {
 }
 
 fn list_resources() -> Vec<String> {
-    let mut files: Vec<String> = vec!["AGENTS.md".to_string()];
+    let mut files: Vec<String> = vec!["BASE_AGENTS.md".to_string()];
     match list_avatar_files() {
         Ok(avatars) => {
             for avatar in avatars {
@@ -56,8 +56,8 @@ async fn handle_resources_list() -> Value {
 }
 
 async fn handle_resources_read(uri: &str) -> Value {
-    if uri == "AGENTS.md" {
-        return match task::spawn_blocking(|| fs::read_to_string("AGENTS.md")).await {
+    if uri == "BASE_AGENTS.md" {
+        return match task::spawn_blocking(|| fs::read_to_string("BASE_AGENTS.md")).await {
             Ok(Ok(content)) => json!({"contents": content}),
             Ok(Err(e)) => json!({"error": {"code": -32000, "message": e.to_string()}}),
             Err(e) => json!({"error": {"code": -32000, "message": e.to_string()}}),
@@ -203,7 +203,7 @@ mod tests {
         assert_eq!(
             uris,
             vec![
-                "AGENTS.md",
+                "BASE_AGENTS.md",
                 "avatars/ANALYST.md",
                 "avatars/ARCHITECT.md",
                 "avatars/DEVELOPER.md",
@@ -215,8 +215,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reads_agents_md() {
-        let result = handle_resources_read("AGENTS.md").await;
+    async fn reads_base_agents_md() {
+        let result = handle_resources_read("BASE_AGENTS.md").await;
         assert!(result.get("contents").is_some());
     }
 }


### PR DESCRIPTION
## Summary
- add BASE_AGENTS.md for avatar consumers (F:BASE_AGENTS.md#L1-L8)
- serve BASE_AGENTS.md via resource endpoints (F:src/server.rs#L36-L47, F:src/server.rs#L58-L64)
- deploy BASE_AGENTS.md in Pages workflow (F:.github/workflows/pages.yml#L29-L32)

## Testing
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_689a5eef5c8883329b061b2589b120a2