### PR TITLE
ci: fix clippy invocation and deploy pages after merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,6 @@ jobs:
           override: true
           components: clippy, rustfmt
       - run: cargo fmt --all -- --check
-      - run: cargo clippy --all-targets --all-features -D warnings
+      - run: cargo check --tests --benches
+      - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo test

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,11 +1,9 @@
 name: Deploy Pages
 
 on:
-  push:
-    branches: [main]
-    tags:
-      - 'v*'
-  workflow_dispatch:
+  workflow_run:
+    workflows: ["Rust CI"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -18,9 +16,12 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable


### PR DESCRIPTION
## Summary
- run `cargo check` before linting
- fix clippy flag syntax
- deploy GitHub Pages after Rust CI succeeds on main

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_689a75dab3f883329befc5022b9505a7