### PR TITLE
Add top-level instructions and update pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,6 +31,8 @@ jobs:
           mkdir -p public/avatars
           cp -r avatars/* public/avatars/
           cp BASE_AGENTS.md public/
+          cp INSTRUCTIONS.md public/
+          cp INSTRUCTIONS.md public/index.md
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/BASE_AGENTS.md
+++ b/BASE_AGENTS.md
@@ -1,9 +1,9 @@
 # Base Agent Instructions
 
-Use these avatars to guide agent behavior.
+These guidelines apply to every avatar in this repository.
 
-- Each file in `avatars/` describes a distinct persona.
-- Choose the avatar that matches your task.
-- Provide the avatar text as part of the system prompt.
-- Keep interactions consistent with the selected persona.
+- Each Markdown file in `avatars/` defines a distinct persona.
+- Select the avatar that best fits your task.
+- Include the avatar's text in the system prompt.
+- Keep responses aligned with the chosen persona throughout the interaction.
 

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -1,0 +1,5 @@
+# Instructions
+
+- `GET /avatars/{id}.md` — access the full profile for the avatar with the given `id`.
+- `GET /BASE_AGENTS.md` — access the shared instruction set for all avatars.
+


### PR DESCRIPTION
## Summary
- add INSTRUCTIONS.md with links to avatar profiles and base instructions (F:INSTRUCTIONS.md#L1-L4)
- expand BASE_AGENTS.md with common guidelines for avatars (F:BASE_AGENTS.md#L1-L8)
- copy instruction files and set INSTRUCTIONS.md as default page in Pages workflow (F:.github/workflows/pages.yml#L30-L35)

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_689a79cda2d0833280ee0e35603f4a46