### PR TITLE
Set default run binary for cargo run

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "avatars_generator"
 version = "0.1.0"
 edition = "2024"
+default-run = "avatars_generator"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Specify `default-run` in Cargo.toml so `cargo run --release` selects the correct binary

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete` *(fails: no such command)*
- `cargo run --release`


------
https://chatgpt.com/codex/tasks/task_e_689a7aa16628833280ee4e0a5a4a6ef0