### PR TITLE
docs: refine instructions for GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,8 +30,7 @@ jobs:
       - run: |
           mkdir -p public/avatars
           cp -r avatars/* public/avatars/
-          cp BASE_AGENTS.md public/
-          cp INSTRUCTIONS.md public/
+          cp BASE_AGENTS.md INSTRUCTIONS.md public/
           cp INSTRUCTIONS.md public/index.md
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -1,5 +1,5 @@
 # Instructions
 
-- `GET /avatars/{id}.md` — access the full profile for the avatar with the given `id`.
-- `GET /BASE_AGENTS.md` — access the shared instruction set for all avatars.
+- `GET /avatars/{id}.md` — retrieve the complete descriptor for the avatar with the given `id`.
+- `GET /BASE_AGENTS.md` — retrieve the shared instruction set.
 


### PR DESCRIPTION
## Summary
- clarify API instruction references
- streamline GitHub Pages workflow

## Testing
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_689a8366fc5c8332a4f1378877d65caa