### PR TITLE
Remove merge and rebase references from instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,6 @@
 - Treat user requests as complete tasks and deliver full pull-request solutions.
 - Remove dead code instead of suppressing warnings; feature-gate unused code when necessary.
 - Write tests for new functionality and resolve any reported problems.
-- Clone repositories from their official source, work on the `main` branch, and keep `origin` configured for rebasing.
 - Pipeline secrets are stored in the `prod` environment.
 - After completing a task, verify that the current branch's HEAD matches `origin/main`; if `origin/main` has advanced, restart the task from the latest commit.
 

--- a/avatars/ARCHITECT.md
+++ b/avatars/ARCHITECT.md
@@ -36,4 +36,4 @@ A passionate system architect who lives for building reliable, scalable, and ele
 
 > **Note:**  
 > Architecture diagram sources must be stored in the `.mmd` (Mermaid) format.  
-> Diagram generation (SVG/PNG) is handled by the CI pipeline after merge requests are accepted; generated diagrams are then added to the repository automatically.
+> Diagram generation (SVG/PNG) is handled by the CI pipeline after pull requests are accepted; generated diagrams are then added to the repository automatically.

--- a/avatars/DEVOPS.md
+++ b/avatars/DEVOPS.md
@@ -38,12 +38,12 @@ A pragmatic and automation-obsessed DevOps engineer who ensures the team’s CI/
 - [`cargo-nextest`](https://nexte.st/) — parallel and reproducible test runner
 - [`cargo-tarpaulin`](https://github.com/xd009642/tarpaulin) — coverage in pipeline
 - [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) — declarative, fast installation of Rust binaries (for build agents)
-- [`gitui`](https://github.com/extrawurst/gitui) — Rust terminal git UI, helps with review/merge process
+- [`gitui`](https://github.com/extrawurst/gitui) — Rust terminal git UI, helps with review process
 - [`starship`](https://starship.rs/) — Rust prompt for dev shells and pipelines
 - [`fd`](https://github.com/sharkdp/fd), [`bat`](https://github.com/sharkdp/bat`), [`ripgrep`](https://github.com/BurntSushi/ripgrep) — for scripting, pipeline checks and DX
 
 ## Example Tasks
 - Refactor and document the team’s CI pipeline into clean, reusable templates (e.g. GitHub Actions composite workflows, `.justfile`, `Makefile.toml`, `default.nix`)
 - Setup devshell for every project and make onboarding one-command
-- Ensure test, lint, coverage, and build all run in CI before merging
+- Ensure test, lint, coverage, and build all run in CI before integration
 - Add pipeline status badges and automated release notes to docs

--- a/avatars/SECURITY.md
+++ b/avatars/SECURITY.md
@@ -36,7 +36,7 @@ unauthorized changes.
 - `openscap` — compliance and vulnerability checks
 
 ## Example Tasks
-- Add automated security scans to merge request pipelines
+- Add automated security scans to pull request pipelines
 - Review infrastructure code for misconfigurations
 - Establish code signing and verification for releases
 - Monitor dependency updates for security patches


### PR DESCRIPTION
## Summary
- Drop rebasing requirement from universal agent guidelines
- Rephrase avatar instructions to avoid merge terminology
- Remove cloning-from-main-branch directive from workflow guidelines

## Testing
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_689a90aa2eac83329ea042db143c2020