### PR TITLE
docs: fix GitHub Pages URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ cargo test
 The latest version of the avatar API is served from GitHub Pages at:
 
 ```
-https://qqrm.github.io/avatars-mcp/
+https://qqrm.github.io/
 ```
 
 You can browse individual avatar files or fetch `avatars/index.json` from that URL, for example:
 
 ```
-https://qqrm.github.io/avatars-mcp/avatars/index.json
+https://qqrm.github.io/avatars/index.json
 ```
 
 ### Release Versioning


### PR DESCRIPTION
## Summary
- point published API docs to the root GitHub Pages URL

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_689ab25fe8e8833292c3f487b0f0657a