### PR TITLE
Serve Markdown index for Pages API

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,19 @@ jobs:
           mkdir -p public/avatars
           cp -r avatars/* public/avatars/
           cp BASE_AGENTS.md INSTRUCTIONS.md public/
-          cp INSTRUCTIONS.md public/index.md
+          cp avatars/index.json public/index.json
+          {
+            cat BASE_AGENTS.md
+            echo
+            echo "## Avatars"
+            for f in avatars/*.md; do
+              name=$(basename "$f")
+              echo "- [${name%.*}](avatars/$name)"
+            done
+            echo
+            cat INSTRUCTIONS.md
+          } > public/index.md
+          touch public/.nojekyll
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- generate Markdown index with avatar links for GitHub Pages
- remove HTML root; publish JSON and Markdown API files

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete` *(fails: no such command: `machete`)*

------
https://chatgpt.com/codex/tasks/task_e_689ac23ef660833292e255bb7a0ada5d