### PR TITLE
docs: update GitHub Pages URL

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -1,5 +1,11 @@
 # Instructions
 
+The avatar API is available at:
+
+```text
+https://qqrm.github.io/avatars-mcp/
+```
+
 - `GET /avatars/index.json` — retrieve base instructions and the avatar catalog.
 - `GET /avatars/{id}.md` — retrieve the complete descriptor for the avatar with the given `id`.
 

--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ cargo test
 The latest version of the avatar API is served from GitHub Pages at:
 
 ```
-https://qqrm.github.io/
+https://qqrm.github.io/avatars-mcp/
 ```
 
 You can browse individual avatar files or fetch `avatars/index.json` from that URL, for example:
 
 ```
-https://qqrm.github.io/avatars/index.json
+https://qqrm.github.io/avatars-mcp/avatars/index.json
 ```
 
 ### Release Versioning


### PR DESCRIPTION
## Summary
- note avatar API base URL in instructions F:INSTRUCTIONS.md#L3-L7
- update README to use new GitHub Pages path F:README.md#L127-L136

## Testing
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_689ae42193488332ab3028fb56117578