### PR TITLE
docs: add avatar API URL to agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 # Universal Agent Instructions
 
+## Avatars
+- Retrieve avatars from `https://qqrm.github.io/avatars-mcp/`.
+
 ## Strategy
 - Review `AGENTS.md` files in the current scope before making changes.
 - Consult repository documentation such as `ARCHITECTURE.md` or `SPECIFICATION.md` if available.


### PR DESCRIPTION
## Summary
- document avatar API URL in agent instructions `F:AGENTS.md#L3-L4`

## Testing
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_689afbc53a7c8332ae6e0ff02220fb6b