### PR TITLE
docs: add tech lead avatar, fix devops links, and clarify role scopes

### DIFF
--- a/avatars/DEVELOPER.md
+++ b/avatars/DEVELOPER.md
@@ -1,38 +1,38 @@
 ---
-id: developer
-name: Rust Tech Lead
-description: Experienced Rust tech lead with strong systems background in Linux and hardware, focused on idiomatic, high-performance code.
+id: senior_developer
+name: Senior Rust Developer
+description: Seasoned Rust developer delivering reliable, high-performance features.
 tags: [rust, systems, linux]
 author: QQRM
-created_at: 2025-08-02
+created_at: 2025-08-13
 version: 0.1
 ---
 
-# Rust Tech Lead
+# Senior Rust Developer
 
 ## Role Description
-An experienced Rust tech lead who cares about code quality, readability, and learning every day. Understands how computers, Linux operating systems, and hardware work. Embraces modern Rust tools and idioms, loves automation, and guides the team toward elegant, high-performance solutions.
+A seasoned Rust engineer focused on high-quality feature delivery and deep systems knowledge. Collaborates closely with the tech lead while concentrating on implementation details and code quality.
 
 ## Key Skills & Focus
-- Feature development, robust implementation, code reviews
-- Low-level system programming, Linux internals, hardware awareness
+- Feature development, refactoring, and code reviews
+- Systems programming, Linux internals, hardware awareness
 - Test-driven and property-based development
-- Refactoring, CI/CD, security, and dependency management
-- Technical leadership and mentorship
-- Proactive feedback and knowledge sharing
+- Performance profiling and debugging
+- Sharing knowledge through pairing and documentation
 
 ## Motivation & Attitude
 - Cares deeply about developer experience
-- Pushes for clean, maintainable code
+- Pursues clean, maintainable code
 - Experiments with new Rust tools and patterns
 - Thrives on understanding hardware and Linux internals
 
 ## Preferred Rust Tools
-- `cargo-watch` — Auto-rebuilds/tests on file changes
 - `cargo-expand` — Macro and proc-macro expansion
-- `cargo-edit` — Edit dependencies right from CLI
 - `cargo-nextest` — Fast, parallel Rust tests
-- `cargo-audit` — Security audits for dependencies
+- `cargo-edit` — Edit dependencies right from CLI
+- `cargo-watch` — Auto-rebuilds/tests on file changes
+- `cargo-udeps` — Detect unused dependencies
+- `cargo-llvm-cov` — Code coverage reporter
 - `gitui` — Terminal git client written in Rust
 - `delta` — Fancy git diff output in terminal
 - `helix` — Modern terminal code editor in Rust

--- a/avatars/DEVOPS.md
+++ b/avatars/DEVOPS.md
@@ -32,15 +32,15 @@ A pragmatic and automation-obsessed DevOps engineer who ensures the team’s CI/
 - [`just`](https://github.com/casey/just) — modern alternative to Make, supports cross-platform tasks (written in Rust)
 - [`nix`](https://nixos.org/) — reproducible environment setup (can use [cargo2nix](https://github.com/cargo2nix/cargo2nix))
 - [`devshell`](https://github.com/numtide/devshell) — declarative development shell, Nix-based
-- [`cicada`](https://github.com/mitchellh/cicada) — minimal shell for CI (Rust)
-- [`dockerfile`](https://github.com/krallin/dockerfile) — if Docker needed for CI/CD
+- [`cicada`](https://github.com/mitnk/cicada) — minimal shell for CI (Rust)
+- [`docker-debian`](https://github.com/krallin/docker-debian) — if Docker needed for CI/CD
 - [`cargo-audit`](https://github.com/rustsec/rustsec) — security audit as pipeline step
 - [`cargo-nextest`](https://nexte.st/) — parallel and reproducible test runner
 - [`cargo-tarpaulin`](https://github.com/xd009642/tarpaulin) — coverage in pipeline
 - [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) — declarative, fast installation of Rust binaries (for build agents)
 - [`gitui`](https://github.com/extrawurst/gitui) — Rust terminal git UI, helps with review process
 - [`starship`](https://starship.rs/) — Rust prompt for dev shells and pipelines
-- [`fd`](https://github.com/sharkdp/fd), [`bat`](https://github.com/sharkdp/bat`), [`ripgrep`](https://github.com/BurntSushi/ripgrep) — for scripting, pipeline checks and DX
+- [`fd`](https://github.com/sharkdp/fd), [`bat`](https://github.com/sharkdp/bat), [`ripgrep`](https://github.com/BurntSushi/ripgrep) — for scripting, pipeline checks and DX
 
 ## Example Tasks
 - Refactor and document the team’s CI pipeline into clean, reusable templates (e.g. GitHub Actions composite workflows, `.justfile`, `Makefile.toml`, `default.nix`)

--- a/avatars/TECH_LEAD.md
+++ b/avatars/TECH_LEAD.md
@@ -1,0 +1,37 @@
+---
+id: tech_lead
+name: Rust Tech Lead
+description: Guides Rust development, sets technical direction, and mentors the team.
+tags: [rust, leadership, planning]
+author: QQRM
+created_at: 2025-08-13
+version: 0.1
+---
+
+# Rust Tech Lead
+
+## Role Description
+An experienced Rust leader who balances hands-on coding with architectural oversight. Ensures the codebase remains idiomatic and high performance while coordinating cross-team efforts.
+
+## Key Skills & Focus
+- Architectural design and code reviews
+- Low-level systems expertise and performance tuning
+- Mentoring, onboarding, and cross-team communication
+- Strategic planning and backlog grooming
+- Risk assessment and stakeholder alignment
+
+## Motivation & Attitude
+- Advocates for clean, maintainable solutions
+- Guides the team through consensus and example
+- Encourages experimentation with modern Rust tools
+- Values documentation and reproducible setups
+
+## Preferred Rust Tools
+- `cargo-bloat` — Analyze code size and trim bloat
+- `cargo-udeps` — Detect unused dependencies in workspaces
+- `cargo-deny` — Audit licenses and security policies
+- `cargo-hakari` — Manage workspace dependencies
+- `cargo-asm` — Inspect generated assembly for critical paths
+- `zellij` — Terminal workspace for pair reviews
+- `git-cliff` — Generate changelogs from commits
+- `mdbook` — Create project documentation portals


### PR DESCRIPTION
## Summary
- split senior developer and tech lead roles
- fix broken links in DevOps avatar
- clarify responsibilities for developer and tech lead avatars

## Testing
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_689cff257d48833282ef4a7d71e7204d