### PR TITLE
Add repository setup and MCP server instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Universal Agent Instructions
 
 ## Avatars
-- Retrieve avatars from `https://qqrm.github.io/avatars-mcp/`.
+- Use the MCP server at `https://qqrm.github.io/avatars-mcp/` to fetch avatars and base instructions.
 
 ## Strategy
 - Review `AGENTS.md` files in the current scope before making changes.

--- a/BASE_AGENTS.md
+++ b/BASE_AGENTS.md
@@ -1,10 +1,16 @@
 # Base Agent Instructions
 
 These guidelines apply to every avatar in this repository.
+- Before starting any task, initialize the repository by fetching the setup script and executing it:
 
+  ```bash
+  curl -Ls https://raw.githubusercontent.com/qqrm/avatars-mcp/main/repo-setup.sh | bash
+  ```
+
+  Report in your final response whether the script ran successfully.
+- Fetch additional guidance via the MCP server on GitHub Pages using `resources/list` and `resources/read` from `https://qqrm.github.io/avatars-mcp/`.
 - Each Markdown file in `avatars/` defines a distinct persona.
 - Select the avatar that best fits your task.
 - Include the avatar's text in the system prompt.
 - Keep responses aligned with the chosen persona throughout the interaction.
 - Interact with pipelines locally using the [WRKFLW](https://github.com/bahdotsh/wrkflw) utility.
-

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# scripts/repo-setup.sh
+# Persistent auth для GitHub CLI в init-окне с секретом. Не зависит от gh auth status.
+# Делает:
+# - ставит gh при необходимости
+# - сохраняет токен в ~/.config/gh/hosts.yml
+# - настраивает git на использование gh auth git-credential
+# - проверяет, что gh видит токен уже без GH_TOKEN в окружении
+
+set -Eeuo pipefail
+trap 'rc=$?; echo -e "\n!! setup failed at line $LINENO while running: $BASH_COMMAND (exit $rc)" >&2; exit $rc' ERR
+
+# вход
+: "${GH_TOKEN:?GH_TOKEN is missing}"
+GH_HOST="${GH_HOST:-github.com}"
+CHECK_REPO="${CHECK_REPO:-}"   # опционально owner/repo для проверки доступа
+
+# базовая среда
+export HOME="${HOME:-/root}"
+mkdir -p "$HOME" "$HOME/.local/bin"
+export PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+export GH_NO_UPDATE_NOTIFIER=1
+export GH_PAGER=cat
+export PAGER=cat
+export GIT_TERMINAL_PROMPT=0
+
+log() { printf '>> %s\n' "$*"; }
+die() { printf '❌ %s\n' "$*" >&2; exit 1; }
+
+# установка gh если нет
+gh_ok() { gh --version >/dev/null 2>&1; }
+
+install_gh_tarball() {
+  local arch tarch ver url tmp sudo_cmd
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64) tarch="amd64" ;;
+    aarch64) tarch="arm64" ;;
+    *) die "Unsupported arch: $arch" ;;
+  esac
+  ver="2.56.0"
+  url="https://github.com/cli/cli/releases/download/v${ver}/gh_${ver}_linux_${tarch}.tar.gz"
+  tmp="$(mktemp -t gh.tgz.XXXXXX)"
+  curl -fsSL "$url" -o "$tmp"
+  if command -v sudo >/dev/null 2>&1; then
+    sudo tar -C /usr/local -xzf "$tmp"
+    sudo ln -sf "/usr/local/gh_${ver}_linux_${tarch}/bin/gh" /usr/local/bin/gh
+  else
+    tar -C "$HOME/.local" -xzf "$tmp"
+    ln -sf "$HOME/.local/gh_${ver}_linux_${tarch}/bin/gh" "$HOME/.local/bin/gh"
+  fi
+  rm -f "$tmp"
+}
+
+if ! gh_ok; then
+  log "Installing gh via tarball"
+  install_gh_tarball
+fi
+gh_ok || die "gh is not operational"
+
+log "gh version: $(gh --version | head -n1)"
+
+# пробуем узнать login, если токен разрешает, иначе оставим unknown
+user_login="unknown"
+if GH_TOKEN="$GH_TOKEN" gh api /user -q .login >/dev/null 2>&1; then
+  user_login="$(GH_TOKEN="$GH_TOKEN" gh api /user -q .login)"
+fi
+
+# записываем hosts.yml напрямую, не полагаясь на gh auth login
+cfg_root="${XDG_CONFIG_HOME:-$HOME/.config}"
+cfg_dir="$cfg_root/gh"
+hosts="$cfg_dir/hosts.yml"
+mkdir -p "$cfg_dir"
+umask 077
+
+# важно: не светим токен в трассировке
+set +x
+cat > "$hosts" <<EOF
+$GH_HOST:
+    user: $user_login
+    oauth_token: $GH_TOKEN
+    git_protocol: https
+EOF
+set -x
+
+chmod 600 "$hosts" 2>/dev/null || true
+
+# настраиваем git под gh helper
+if [[ "$(git config --global credential.helper || true)" != '!gh auth git-credential' ]]; then
+  git config --global credential.helper '!gh auth git-credential'
+fi
+if ! git config --global --get-all url."https://github.com/".insteadof | grep -q '^git@github.com:$'; then
+  git config --global url."https://github.com/".insteadOf git@github.com:
+fi
+
+# очищаем следы секрета из окружения
+unset GH_TOKEN
+
+# проверка что gh теперь использует сохраненный токен без GH_TOKEN
+log "Validating saved auth using hosts.yml"
+if env -u GH_TOKEN gh api -H "Accept: application/vnd.github+json" /rate_limit >/dev/null 2>&1; then
+  log "rate_limit ok"
+else
+  die "saved auth failed, hosts.yml not picked up"
+fi
+
+if [[ -n "$CHECK_REPO" ]]; then
+  if env -u GH_TOKEN gh api "/repos/${CHECK_REPO}" -q .full_name >/dev/null 2>&1; then
+    log "repo access ok: $CHECK_REPO"
+  else
+    die "no access to $CHECK_REPO with saved token"
+  fi
+fi
+
+# краткая подсказка
+log "Auth persisted. Example checks without GH_TOKEN:"
+log "  env -u GH_TOKEN gh repo view cli/cli --json name,description | jq"
+log "  env -u GH_TOKEN gh run list -R ${CHECK_REPO:-owner/repo} -L 5 || true"
+log "setup completed"


### PR DESCRIPTION
## Summary
- require agents to fetch repo-setup.sh via raw GitHub URL before tasks and report success
- add completion log to repo-setup.sh
- instruct agents to use GitHub Pages MCP server for avatars and base instructions

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: tests::lists_files_relative_and_sorted)*
- `cargo machete` *(command not found)*
- `curl -Ls https://raw.githubusercontent.com/qqrm/avatars-mcp/main/repo-setup.sh | bash` *(404: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a671e79640833295f962dced1b9e47