### PR TITLE
Document dtolnay rust-toolchain pipelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 - Write tests for new functionality and resolve any reported problems.
 - Pipeline secrets are stored in the `prod` environment.
 - Interact with pipelines locally using the [WRKFLW](https://github.com/bahdotsh/wrkflw) utility to validate and run GitHub workflows.
+- Use the [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) pipelines for Rust projects; they are our required modern standard.
 - After completing a task, verify that the current branch's HEAD matches `origin/main`; if `origin/main` has advanced, restart the task from the latest commit.
 
 ## Pre-commit Checks

--- a/avatars/DEVOPS.md
+++ b/avatars/DEVOPS.md
@@ -27,6 +27,7 @@ A pragmatic and automation-obsessed DevOps engineer who ensures the team’s CI/
 - Shares DevOps knowledge with the whole team
 
 ## Preferred Rust (and declarative) Tools
+- [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) — modern GitHub Action pipelines that we must adopt.
 - [`cargo-make`](https://github.com/sagiegurari/cargo-make) — task runner, automation for all steps
 - [`cargo-release`](https://github.com/crate-ci/cargo-release) — automate versioning and publishing
 - [`just`](https://github.com/casey/just) — modern alternative to Make, supports cross-platform tasks (written in Rust)

--- a/src/server.rs
+++ b/src/server.rs
@@ -155,6 +155,7 @@ mod tests {
                 "DEVELOPER.md",
                 "DEVOPS.md",
                 "SECURITY.md",
+                "TECH_LEAD.md",
                 "TESTER.md",
             ]
         );


### PR DESCRIPTION
## Summary
- Document dtolnay/rust-toolchain as the required Rust CI pipeline.
- Highlight dtolnay/rust-toolchain in DevOps avatar guidance.
- Align avatar file list test with repository contents.

## Testing
- `rustup component add clippy rustfmt`
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_68a68567aae08332bbfecf0974531953