### PR TITLE
Ensure repo setup script creates AGENTS.md

### DIFF
--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -27,6 +27,15 @@ export GIT_TERMINAL_PROMPT=0
 log() { printf '>> %s\n' "$*"; }
 die() { printf '❌ %s\n' "$*" >&2; exit 1; }
 
+# ensure AGENTS.md exists
+if [ ! -f AGENTS.md ]; then
+  curl -fsSL https://qqrm.github.io/avatars-mcp/BASE_AGENTS.md -o AGENTS.md \
+    || cp BASE_AGENTS.md AGENTS.md
+  log "AGENTS.md created"
+else
+  log "AGENTS.md already exists"
+fi
+
 # gh installation if missing
 gh_ok() { gh --version >/dev/null 2>&1; }
 


### PR DESCRIPTION
## Summary
- ensure AGENTS.md exists during setup (F:repo-setup.sh#L30-L37)

## Testing
- `rustup component add clippy rustfmt`
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68b35c25f7e4833293a1a08c6c43ba97