### PR TITLE
Install setup tools from prebuilt binaries

### DIFF
--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -96,14 +96,14 @@ cargo_binstall_ok || die "cargo-binstall is not operational"
 
 if ! command -v cargo-machete >/dev/null 2>&1; then
   log "Installing cargo-machete via cargo-binstall"
-  cargo binstall cargo-machete -y
+  cargo binstall cargo-machete -y --quiet --disable-strategies compile
 fi
 command -v cargo-machete >/dev/null 2>&1 || die "cargo-machete installation failed"
 
 # install wrkflw using cargo-binstall with tarball fallback
 if ! command -v wrkflw >/dev/null 2>&1; then
   log "Installing wrkflw via cargo-binstall"
-  if ! cargo binstall wrkflw@0.7.0 -y; then
+  if ! cargo binstall wrkflw@0.7.0 -y --quiet --disable-strategies compile; then
     log "Falling back to wrkflw tarball"
     arch="$(uname -m)"
     case "$arch" in


### PR DESCRIPTION
## Summary
- revert quiet/trace variables from setup script
- install cargo-machete and wrkflw via prebuilt binaries only

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68b6036c96448332a2e80f0239332840