### PR TITLE
docs: expose local MCP servers and publish config

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ jobs:
       - run: |
           mkdir -p public/avatars
           cp -r avatars/* public/avatars/
-          cp BASE_AGENTS.md INSTRUCTIONS.md public/
+          cp BASE_AGENTS.md INSTRUCTIONS.md mcp.json public/
           cp avatars/index.json public/index.json
           {
             cat BASE_AGENTS.md

--- a/BASE_AGENTS.md
+++ b/BASE_AGENTS.md
@@ -6,8 +6,20 @@ These guidelines apply to every avatar in this repository.
 - Use the MCP server at `https://qqrm.github.io/avatars-mcp/` to fetch avatars and base instructions.
 
 ## Rust Documentation Servers
-- `repo-setup.sh` installs the `cargo-mcp` and `crates-mcp` servers.
+- `repo-setup.sh` installs the `cargo-mcp` and `crates-mcp` servers via `cargo-binstall` with a source fallback.
 - A default `mcp.json` enables these servers automatically.
+
+## Local MCP servers
+- **cargo** – command `cargo-mcp`.
+  Example request:
+  ```json
+  { "tool": "workspace_crates", "directory": "." }
+  ```
+- **crates** – command `crates-mcp`.
+  Example request:
+  ```json
+  { "tool": "search_crates", "query": "http client" }
+  ```
 
 ## Dynamic Avatar Switching
 - Switch avatars through the MCP server as needed for sub-tasks (e.g., Senior, Architect, Tester, Analyst).

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -134,7 +134,7 @@ command -v wrkflw >/dev/null 2>&1 || die "wrkflw installation failed"
 for mcp_pkg in cargo-mcp crates-mcp; do
   if ! command -v "$mcp_pkg" >/dev/null 2>&1; then
     log "Installing $mcp_pkg via cargo-binstall"
-    cargo binstall "$mcp_pkg" -y --quiet --disable-strategies compile
+    cargo binstall "$mcp_pkg" -y --quiet
   fi
   command -v "$mcp_pkg" >/dev/null 2>&1 || die "$mcp_pkg installation failed"
 done


### PR DESCRIPTION
## Summary
- document cargo and crates MCP servers with sample requests
- copy mcp.json in Pages workflow for startup configuration
- let cargo-binstall compile cargo-mcp and crates-mcp when binaries are missing

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68b7ef7c0a5c8332b42a138bf233644b