### PR TITLE
Restore instructions file for GitHub Pages build

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -1,0 +1,10 @@
+# Instructions
+
+The avatar API is available at:
+
+```text
+https://qqrm.github.io/avatars-mcp/
+```
+
+- `GET /avatars/index.json` — retrieve base instructions and the avatar catalog.
+- `GET /avatars/{id}.md` — retrieve the complete descriptor for the avatar with the given `id`.


### PR DESCRIPTION
## Summary
- restore `INSTRUCTIONS.md` so Pages can copy metadata and ship `mcp.json`

## Testing
- `cargo fmt --all`
- `wrkflw run .github/workflows/pages.yml` *(fails: Docker not available, syntax error in shell block)*

------
https://chatgpt.com/codex/tasks/task_e_68b802f776ac8332a9d5334a56646293