### PR TITLE
Rename initialization script to setup.sh

### DIFF
--- a/BASE_AGENTS.md
+++ b/BASE_AGENTS.md
@@ -6,15 +6,10 @@ These guidelines apply to every avatar in this repository.
 - Use the MCP server at `https://qqrm.github.io/avatars-mcp/` to fetch avatars and base instructions.
 
 ## Rust Documentation Servers
-- `repo-setup.sh` installs the `cargo-mcp` and `crates-mcp` servers via `cargo-binstall` with a source fallback.
-- A default `mcp.json` enables these servers automatically.
+- `setup.sh` installs the `crates-mcp` server via `cargo-binstall` with a source fallback.
+- A default `mcp.json` enables this server automatically.
 
 ## Local MCP servers
-- **cargo** – command `cargo-mcp`.
-  Example request:
-  ```json
-  { "tool": "workspace_crates", "directory": "." }
-  ```
 - **crates** – command `crates-mcp`.
   Example request:
   ```json

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Example configuration for an MCP client:
 }
 ```
 
-The repository also publishes a default `mcp.json` that enables the `cargo-mcp` and `crates-mcp` servers for Rust documentation.
+The repository also publishes a default `mcp.json` that enables the `crates-mcp` server for Rust documentation.
 
 ### Generator (Rust)
 

--- a/mcp.json
+++ b/mcp.json
@@ -1,12 +1,9 @@
 {
   "mcpServers": [
     {
-      "name": "cargo",
-      "command": "cargo-mcp"
-    },
-    {
       "name": "crates",
       "command": "crates-mcp"
     }
   ]
 }
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/repo-setup.sh
+# scripts/setup.sh
 # Persistent auth для GitHub CLI в init-окне с секретом. Не зависит от gh auth status.
 # Делает:
 # - ставит gh при необходимости


### PR DESCRIPTION
## Summary
- rename initialization script to `setup.sh` (F:setup.sh#L1-L2)
- document that `setup.sh` installs only the `crates-mcp` server (F:setup.sh#L133-L140)
- update base instructions, README, and `mcp.json` to reference only `crates-mcp` (F:BASE_AGENTS.md#L8-L17, F:README.md#L103, F:mcp.json#L1-L8)

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68b83afdfa7483328faf8a3a5b12fe8b