### PR TITLE
docs: mention optional local setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@
 - In the final summary, list all avatars used to solve the task.
 
 ## Development Workflow
+- If a `local_setup.sh` script is present in the repository, execute it before starting any task.
 - Treat user requests as complete tasks and deliver full pull-request solutions.
 - Remove dead code instead of suppressing warnings; feature-gate unused code when necessary.
 - Write tests for new functionality and resolve any reported problems.

--- a/BASE_AGENTS.md
+++ b/BASE_AGENTS.md
@@ -39,6 +39,7 @@ These guidelines apply to every avatar in this repository.
 - In the final summary, list all avatars used to solve the task.
 
 ## Development Workflow
+- If a `local_setup.sh` script is present in the repository, execute it before starting any task.
 - Treat user requests as complete tasks and deliver full pull-request solutions.
 - Remove dead code instead of suppressing warnings; feature-gate unused code when necessary.
 - Write tests for new functionality and resolve any reported problems.


### PR DESCRIPTION
## Summary
- advise running `local_setup.sh` before tasks when present

## Testing
- `if [ -f local_setup.sh ]; then bash local_setup.sh; else echo 'local_setup.sh not found'; fi`
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b88ca892d0833294043482c78741b9