### PR TITLE
docs: require reviewing recent pipeline logs

### DIFF
--- a/BASE_AGENTS.md
+++ b/BASE_AGENTS.md
@@ -45,6 +45,7 @@ These guidelines apply to every avatar in this repository.
 - Write tests for new functionality and resolve any reported problems.
 - Pipeline secrets are stored in the `prod` environment.
 - Interact with pipelines locally using the [WRKFLW](https://github.com/bahdotsh/wrkflw) utility to validate and run GitHub workflows.
+- Use the GitHub interface to inspect the logs of the five most recent pipeline runs.
 - Use the [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) pipelines for Rust projects; they are our required modern standard.
 - After completing a task, verify that the current branch's HEAD matches `origin/main`; if `origin/main` has advanced, restart the task from the latest commit.
 


### PR DESCRIPTION
## Summary
- mandate reviewing the last five GitHub pipeline logs

## Testing
- `cargo fmt --all` *(fails: feature `edition2024` is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c8bbddc48332998ab695e53a864e