### PR TITLE
setup: execute repo_setup if available

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -195,4 +195,11 @@ fi
 log "Auth persisted. Example checks without GH_TOKEN:"
 log "  env -u GH_TOKEN gh repo view cli/cli --json name,description | jq"
 log "  env -u GH_TOKEN gh run list -R ${CHECK_REPO:-owner/repo} -L 5 || true"
+
+# run repository-specific setup if available
+if [ -f repo_setup.sh ]; then
+  log "Executing repo_setup.sh"
+  bash repo_setup.sh
+fi
+
 log "setup completed"


### PR DESCRIPTION
## Summary
- run repo_setup.sh from setup.sh when present for repository-specific setup

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68c6f190b8948332929bd6d623a398b3