### PR TITLE
Update quest workflow requirements

### DIFF
--- a/BASE_AGENTS.md
+++ b/BASE_AGENTS.md
@@ -37,10 +37,12 @@ These guidelines apply to every avatar in this repository.
 - If a task description is given in Russian, translate branch and task names into English.
 - Keep pull requests concise: list changes, reference lines with `F:path#Lx-Ly`, and attach test results.
 - In the final summary, list all avatars used to solve the task.
+- Provide a link to the open quest (pull request) in the final summary after solving each task.
 
 ## Development Workflow
 - If a `local_setup.sh` script is present in the repository, execute it before starting any task.
 - Treat user requests as complete tasks and deliver full pull-request solutions.
+- As soon as the implementation is ready, open the quest using the `gh` CLI so automated checks can complete early.
 - Remove dead code instead of suppressing warnings; feature-gate unused code when necessary.
 - Write tests for new functionality and resolve any reported problems.
 - Pipeline secrets are stored in the `prod` environment.


### PR DESCRIPTION
## Summary
* Require agents to open quests with the `gh` CLI as soon as work is ready so automated checks start promptly. F:BASE_AGENTS.md#L43-L46
* Direct agents to include a link to the open quest in each final summary. F:BASE_AGENTS.md#L35-L41

## Testing
- Not Run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c8f15e31988332aa0bc0eb58806c3d