### PR TITLE
Update base instructions for remote setup

### DIFF
--- a/BASE_AGENTS.md
+++ b/BASE_AGENTS.md
@@ -41,6 +41,7 @@ These guidelines apply to every avatar in this repository.
 
 ## Development Workflow
 - If a `local_setup.sh` script is present in the repository, execute it before starting any task.
+- Ensure git remotes are configured; `repo_setup.sh` must set up the remote automatically.
 - Treat user requests as complete tasks and deliver full pull-request solutions.
 - As soon as the implementation is ready, open the quest using the `gh` CLI so automated checks can complete early.
 - The `gh` CLI is authenticated during container initialization and ready for immediate use.


### PR DESCRIPTION
## Summary
- document that git remotes must be configured automatically during repository setup

## Testing
- not run (markdown-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cabc9420d88332aa792bb2ebae2023