### PR TITLE
Simplify setup sync to shell script

### DIFF
--- a/BASE_AGENTS.md
+++ b/BASE_AGENTS.md
@@ -12,6 +12,7 @@ These guidelines apply to every avatar in this repository.
 ## Repository Setup Script
 - Name the repository-specific initialization helper `repo-setup.sh` in every project.
 - The shared `setup.sh` bootstrapper discovers and runs `repo-setup.sh`, so keep project automation inside that file.
+- Author automation helpers in POSIX shell (`.sh`); avoid introducing alternative scripting runtimes.
 
 ## Local MCP servers
 - **crates** – command `crates-mcp`.

--- a/setup.sh
+++ b/setup.sh
@@ -41,39 +41,13 @@ MCP_BASE_URL="${MCP_BASE_URL:-https://qqrm.github.io/avatars-mcp}"
 AVATAR_DIR="${AVATAR_DIR:-avatars}"
 BASE_FILE="${BASE_FILE:-BASE_AGENTS.md}"
 INDEX_PATH="${INDEX_PATH:-$AVATAR_DIR/index.json}"
-SYNC_MCP_SCRIPT_URL="${SYNC_MCP_SCRIPT_URL:-https://raw.githubusercontent.com/qqrm/avatars-mcp/refs/heads/main/scripts/sync_mcp.rs}"
-export MCP_BASE_URL AVATAR_DIR BASE_FILE INDEX_PATH SYNC_MCP_SCRIPT_URL
+export MCP_BASE_URL AVATAR_DIR BASE_FILE INDEX_PATH
 
 sync_mcp_resources() {
   if bash scripts/sync_mcp.sh; then
     log "MCP resources refreshed from ${MCP_BASE_URL}"
   else
-    die "Failed to sync MCP resources via shell script"
-  command -v cargo >/dev/null 2>&1 || die "cargo is required to sync MCP resources"
-  ensure_rust_script
-  local candidate_path="$SCRIPT_DIR/scripts/sync_mcp.rs"
-  local script_path=""
-  local temp_script=""
-  if [[ "$SCRIPT_SOURCE_IS_STDIN" -eq 0 && -f "$candidate_path" ]]; then
-    script_path="$candidate_path"
-  else
-    temp_script="$(mktemp -t sync_mcp.rs.XXXXXX)"
-    if ! curl -fsSL "$SYNC_MCP_SCRIPT_URL" -o "$temp_script"; then
-      rm -f "$temp_script"
-      die "Unable to download sync_mcp.rs from $SYNC_MCP_SCRIPT_URL"
-    fi
-    script_path="$temp_script"
-  fi
-  if rust-script "$script_path"; then
-    log "MCP resources refreshed from ${MCP_BASE_URL}"
-  else
-    if [ -n "$temp_script" ]; then
-      rm -f "$temp_script"
-    fi
-    die "Failed to sync MCP resources via rust-script"
-  fi
-  if [ -n "$temp_script" ]; then
-    rm -f "$temp_script"
+    die "Failed to sync MCP resources via scripts/sync_mcp.sh"
   fi
 }
 


### PR DESCRIPTION
## Summary
- remove the rust-script fallback so setup relies solely on the shell sync helper `F:setup.sh#L46-L51`
- document that automation helpers must be written as POSIX shell scripts to avoid runtime divergence `F:BASE_AGENTS.md#L12-L16`

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68caeae211a48332a754881963a1ede5