### PR TITLE
Store base instruction path in generated index

### DIFF
--- a/avatars/index.json
+++ b/avatars/index.json
@@ -1,0 +1,100 @@
+{
+  "base_uri": "BASE_AGENTS.md",
+  "avatars": [
+    {
+      "id": "tester",
+      "name": "Automated Test Engineer",
+      "description": "Designs and executes automated test cases to find defects.",
+      "tags": [
+        "testing",
+        "qa"
+      ],
+      "author": "QQRM",
+      "created_at": "2025-08-02",
+      "version": "0.1",
+      "uri": "avatars/TESTER.md"
+    },
+    {
+      "id": "devops_maintainer",
+      "name": "DevOps Engineer",
+      "description": "Maintains reproducible CI/CD pipelines and optimizes automation.",
+      "tags": [
+        "devops",
+        "ci",
+        "automation"
+      ],
+      "author": "QQRM",
+      "created_at": "2025-08-02",
+      "version": "0.1",
+      "uri": "avatars/DEVOPS.md"
+    },
+    {
+      "id": "architect",
+      "name": "Software Architect",
+      "description": "Designs reliable, scalable solutions and drives best practices.",
+      "tags": [
+        "architecture",
+        "design",
+        "rust"
+      ],
+      "author": "QQRM",
+      "created_at": "2025-08-02",
+      "version": "0.1",
+      "uri": "avatars/ARCHITECT.md"
+    },
+    {
+      "id": "senior_developer",
+      "name": "Senior Rust Developer",
+      "description": "Seasoned Rust developer delivering reliable, high-performance features.",
+      "tags": [
+        "rust",
+        "systems",
+        "linux"
+      ],
+      "author": "QQRM",
+      "created_at": "2025-08-13",
+      "version": "0.1",
+      "uri": "avatars/DEVELOPER.md"
+    },
+    {
+      "id": "analyst",
+      "name": "Business Analyst",
+      "description": "Translates business requirements into actionable tasks.",
+      "tags": [
+        "analysis",
+        "requirements"
+      ],
+      "author": "QQRM",
+      "created_at": "2025-08-02",
+      "version": "0.1",
+      "uri": "avatars/ANALYST.md"
+    },
+    {
+      "id": "tech_lead",
+      "name": "Rust Tech Lead",
+      "description": "Guides Rust development, sets technical direction, and mentors the team.",
+      "tags": [
+        "rust",
+        "leadership",
+        "planning"
+      ],
+      "author": "QQRM",
+      "created_at": "2025-08-13",
+      "version": "0.1",
+      "uri": "avatars/TECH_LEAD.md"
+    },
+    {
+      "id": "security",
+      "name": "Security Engineer",
+      "description": "Ensures code and pipelines are secure from attacks.",
+      "tags": [
+        "security",
+        "auditing"
+      ],
+      "author": "QQRM",
+      "created_at": "2025-08-02",
+      "version": "0.1",
+      "uri": "avatars/SECURITY.md"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Replace the stored base instructions with a relative path when generating the index. F:src/lib.rs#L65-L102
- Update the index generation test to validate the new base URI field. F:src/lib.rs#L153-L183
- Regenerate the avatar catalogue with the BASE_AGENTS.md URI and Markdown-only avatar links. F:avatars/index.json#L1-L100

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`
- `cargo run`


------
https://chatgpt.com/codex/tasks/task_e_68cb725558c883328a8bd912dc17a752