### PR TITLE
Stop caching avatar markdown in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -37,147 +37,22 @@ export GIT_TERMINAL_PROMPT=0
 log() { printf '>> %s\n' "$*"; }
 die() { printf '❌ %s\n' "$*" >&2; exit 1; }
 
-validate_relative() {
-  local path="$1"
-  if [[ -z "$path" ]]; then
-    die "Path must not be empty"
-  fi
-  if [[ "$path" == /* ]]; then
-    die "Path '$path' must be relative"
-  fi
-  local IFS='/'
-  read -ra segments <<<"$path"
-  for segment in "${segments[@]}"; do
-    case "$segment" in
-      ''|'.') continue ;;
-      '..') die "Path '$path' must not contain parent directory segments" ;;
-    esac
-  done
-}
-
-build_url() {
-  local base="$1" rel="$2"
-  local trimmed_base="${base%/}"
-  local cleaned_rel="${rel#./}"
-  if [[ -z "$cleaned_rel" ]]; then
-    printf '%s' "$trimmed_base"
-  else
-    printf '%s/%s' "$trimmed_base" "$cleaned_rel"
-  fi
-}
-
-download_file() {
-  local remote_path="$1" dest_path="$2"
-  validate_relative "$remote_path"
-  validate_relative "$dest_path"
-
-  local url tmp dest_abs dest_dir
-  url="$(build_url "$MCP_BASE_URL" "$remote_path")"
-  dest_abs="$SCRIPT_DIR/$dest_path"
-  dest_dir="$(dirname "$dest_abs")"
-  mkdir -p "$dest_dir"
-
-  tmp="$(mktemp -p "${TMPDIR:-/tmp}" sync_mcp.XXXXXX)"
-  if ! curl -fsSL "$url" -o "$tmp"; then
-    rm -f "$tmp"
-    die "Failed to download $url"
-  fi
-
-  local changed=0
-  if [[ -f "$dest_abs" ]] && cmp -s "$tmp" "$dest_abs"; then
-    rm -f "$tmp"
-  else
-    mv "$tmp" "$dest_abs"
-    changed=1
-  fi
-
-  printf '%s' "$changed"
-}
-
-list_avatar_paths() {
-  local index_file="$1"
-  python3 - "$index_file" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-index_path = Path(sys.argv[1])
-with index_path.open('r', encoding='utf-8') as handle:
-    data = json.load(handle)
-for entry in data.get('avatars', []):
-    uri = entry.get('uri')
-    if isinstance(uri, str):
-        value = uri.strip()
-        if value:
-            print(value)
-PY
-}
-
 MCP_BASE_URL="${MCP_BASE_URL:-https://qqrm.github.io/avatars-mcp}"
-AVATAR_DIR="${AVATAR_DIR:-avatars}"
-BASE_FILE="${BASE_FILE:-BASE_AGENTS.md}"
-INDEX_PATH="${INDEX_PATH:-$AVATAR_DIR/index.json}"
-export MCP_BASE_URL AVATAR_DIR BASE_FILE INDEX_PATH
-
-sync_mcp_resources() {
-  command -v curl >/dev/null 2>&1 || die "curl is required"
-  command -v python3 >/dev/null 2>&1 || die "python3 is required"
-  command -v cmp >/dev/null 2>&1 || die "cmp is required"
-
-  validate_relative "$AVATAR_DIR"
-  validate_relative "$BASE_FILE"
-  validate_relative "$INDEX_PATH"
-
-  local total=0
-  local updated=0
-
-  if [[ "$(download_file "$BASE_FILE" "$BASE_FILE")" == "1" ]]; then
-    updated=$((updated + 1))
-  fi
-  total=$((total + 1))
-
-  if [[ "$(download_file "$INDEX_PATH" "$INDEX_PATH")" == "1" ]]; then
-    updated=$((updated + 1))
-  fi
-  total=$((total + 1))
-
-  mapfile -t avatar_paths < <(list_avatar_paths "$SCRIPT_DIR/$INDEX_PATH")
-
-  local avatar_path
-  for avatar_path in "${avatar_paths[@]}"; do
-    validate_relative "$avatar_path"
-    if [[ "$(download_file "$avatar_path" "$avatar_path")" == "1" ]]; then
-      updated=$((updated + 1))
-    fi
-    total=$((total + 1))
-  done
-
-  log "Synced ${total} files (${updated} updated, $((total - updated)) unchanged) from ${MCP_BASE_URL%/}"
-}
+export MCP_BASE_URL
 
 # ensure mcp.json exists
+mcp_url="${MCP_BASE_URL%/}/mcp.json"
 if [ ! -f mcp.json ]; then
-  if curl -fsSL https://qqrm.github.io/avatars-mcp/mcp.json -o mcp.json; then
-    log "mcp.json created"
+  if curl -fsSL "$mcp_url" -o mcp.json; then
+    log "mcp.json created from $mcp_url"
   else
-    log "mcp.json unavailable"
+    log "mcp.json unavailable at $mcp_url"
   fi
 else
   log "mcp.json already exists"
 fi
 
-sync_mcp_resources
-
-if [ ! -f AGENTS.md ]; then
-  if [ -f "$BASE_FILE" ]; then
-    cp "$BASE_FILE" AGENTS.md
-    log "AGENTS.md created from ${BASE_FILE}"
-  else
-    log "${BASE_FILE} missing; skipping AGENTS.md creation"
-  fi
-else
-  log "AGENTS.md already exists"
-fi
+log "Skipping local avatar resource sync; relying on remote MCP server"
 
 # gh installation if missing
 gh_ok() { gh --version >/dev/null 2>&1; }


### PR DESCRIPTION
## Summary
- remove the download helpers and avatar-specific environment variables from `setup.sh`
- keep only the optional MCP base URL to fetch `mcp.json` and log that avatar resources remain remote

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68cb76b0efb08332bca15018d1fe051e