### PR TITLE
Clarify make_pr versus GitHub PR duties

### DIFF
--- a/BASE_AGENTS.md
+++ b/BASE_AGENTS.md
@@ -49,6 +49,8 @@ These guidelines apply to every avatar in this repository.
 - If a `local_setup.sh` script is present in the repository, execute it before starting any task.
 - Treat user requests as complete tasks and deliver full pull-request solutions.
 - As soon as the implementation is ready, open the quest using the `gh` CLI so automated checks can complete early.
+- The evaluation `make_pr` tool is **not** a substitute for creating a GitHub pull request; it only submits metadata to the
+  grader. Always run `gh pr create` (or the equivalent GitHub action) to open the actual pull request.
 - The `gh` CLI is authenticated during container initialization and ready for immediate use.
 - Ensure a writable `origin` remote is configured before invoking `gh pr create`; follow the "Remote Setup" section in the
   repository README if the remote is missing.


### PR DESCRIPTION
## Summary
- Clarified that the evaluation `make_pr` tool does not create GitHub pull requests and reminded agents to run `gh pr create`. 【F:BASE_AGENTS.md†L51-L54】

## Testing
- Not run (markdown-only change).


------
https://chatgpt.com/codex/tasks/task_e_68cb7fc827a08332bc64787c4e7a0edc