### PR TITLE
Sync Agents.md during setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -52,7 +52,13 @@ else
   log "mcp.json already exists"
 fi
 
-log "Skipping local avatar resource sync; relying on remote MCP server"
+# refresh Agents.md from the remote server
+agents_url="${MCP_BASE_URL%/}/Agents.md"
+if curl -fsSL "$agents_url" -o Agents.md; then
+  log "Agents.md refreshed from $agents_url"
+else
+  log "Agents.md unavailable at $agents_url"
+fi
 
 # gh installation if missing
 gh_ok() { gh --version >/dev/null 2>&1; }


### PR DESCRIPTION
## Summary
- download Agents.md from the MCP base URL during setup, overwriting any stale copy 【F:setup.sh#L55-L61】

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68cb821eaeb88332973dfd357e7187bf