### PR TITLE
Configure repo setup remote

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,10 +32,11 @@ jobs:
       - run: |
           mkdir -p public/avatars
           cp -r avatars/* public/avatars/
-          cp BASE_AGENTS.md INSTRUCTIONS.md mcp.json public/
+          cp Agents.md INSTRUCTIONS.md README.md mcp.json public/
           cp avatars/index.json public/index.json
+          cp avatars/index.json public/avatars.json
           {
-            cat BASE_AGENTS.md
+            cat Agents.md
             echo
             echo "## Avatars"
             for f in avatars/*.md; do
@@ -60,3 +61,36 @@ jobs:
     steps:
       - uses: actions/deploy-pages@v4
         id: deployment
+
+  verify-pages:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Smoke test published endpoints
+        run: |
+          set -euo pipefail
+          base_url="https://qqrm.github.io/avatars-mcp"
+          paths=(
+            "index.json"
+            "avatars.json"
+            "avatars/index.json"
+            "Agents.md"
+            "INSTRUCTIONS.md"
+            "README.md"
+            "mcp.json"
+          )
+          sleep 10
+          for path in "${paths[@]}"; do
+            echo "Validating ${base_url}/${path}"
+            for attempt in $(seq 1 5); do
+              if curl --fail --silent --show-error "${base_url}/${path}" > /dev/null; then
+                echo "  OK on attempt ${attempt}"
+                break
+              fi
+              if [[ $attempt -eq 5 ]]; then
+                echo "  Failed after ${attempt} attempts" >&2
+                exit 1
+              fi
+              sleep 5
+            done
+          done

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -6,5 +6,5 @@ The avatar API is available at:
 https://qqrm.github.io/avatars-mcp/
 ```
 
-- `GET /avatars/index.json` — retrieve base instructions and the avatar catalog.
+- `GET /avatars.json` — retrieve base instructions and the avatar catalog (the legacy alias `GET /avatars/index.json` remains available for older clients).
 - `GET /avatars/{id}.md` — retrieve the complete descriptor for the avatar with the given `id`.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Run `./setup.sh` to install the optional MCP servers referenced by `mcp.json`; i
 
 External clients rely on a small set of shared files published alongside the avatars:
 
-- [`Agents.md`](Agents.md) — the baseline instructions served to external agents and bundled into `avatars/index.json`.
+- [`Agents.md`](Agents.md) — the baseline instructions served to external agents and bundled into `avatars.json` (mirrored at the legacy path `avatars/index.json`).
 - [`INSTRUCTIONS.md`](INSTRUCTIONS.md) — a condensed description of the HTTP API exposed via GitHub Pages.
 - [`mcp.json`](mcp.json) — the default Model Context Protocol manifest that activates these resources in compatible clients.
 
@@ -48,14 +48,14 @@ automates only the dependencies it needs while keeping the filename consistent.
 
 ## Tooling
 
-A Rust CLI located in [`src/`](src) regenerates `avatars/index.json` by parsing the avatar front matter and bundling `Agents.md`. Build the index with:
+A Rust CLI located in [`src/`](src) regenerates the catalog (`avatars/index.json`, published to GitHub Pages as both `avatars.json` and `avatars/index.json`) by parsing the avatar front matter and bundling `Agents.md`. Build the index with:
 
 ```bash
 cargo run --release
 ```
 ### GitHub Pages Publishing
 
-The [GitHub Pages workflow](.github/workflows/pages.yml) rebuilds `avatars/index.json` and publishes the `avatars/` directory to GitHub Pages whenever updates land on `main` or release tags. Refer to the workflow file for the complete automation steps.
+The [GitHub Pages workflow](.github/workflows/pages.yml) rebuilds the avatar catalog and publishes it as both `avatars.json` and `avatars/index.json`, alongside the `avatars/` directory, whenever updates land on `main` or release tags. Refer to the workflow file for the complete automation steps.
 
 ### Published API
 
@@ -65,12 +65,12 @@ The latest version of the avatar API is served from GitHub Pages at:
 https://qqrm.github.io/avatars-mcp/
 ```
 
-You can browse individual avatar files or fetch `avatars/index.json` from that URL, for example:
+You can browse individual avatar files or fetch the catalog directly from `avatars.json` (the legacy alias `avatars/index.json` remains available), for example:
 
 ```text
-https://qqrm.github.io/avatars-mcp/avatars/index.json
+https://qqrm.github.io/avatars-mcp/avatars.json
 ```
 
-Continuous integration pipelines lint and test the Rust tooling (`cargo fmt`, `cargo clippy`, and `cargo test`). GitHub Pages deployments rebuild `avatars/index.json` from `main` and publish both the index and avatar Markdown files under `https://qqrm.github.io/avatars-mcp/`.
+Continuous integration pipelines lint and test the Rust tooling (`cargo fmt`, `cargo clippy`, and `cargo test`). GitHub Pages deployments rebuild the catalog from `main` and publish it to both `https://qqrm.github.io/avatars-mcp/avatars.json` and `https://qqrm.github.io/avatars-mcp/avatars/index.json` alongside the avatar Markdown files.
 
 For detailed schemas, examples, and API usage, always defer to `SPECIFICATION.md`.

--- a/REPO_AGENTS.md
+++ b/REPO_AGENTS.md
@@ -1,0 +1,24 @@
+# Repository Agent Instructions
+
+These instructions extend the base `Agents.md` rules for the entire repository.
+
+## Mandatory Setup
+- Before modifying the repository, execute `./repo-setup.sh` from the repository root.
+- After the setup script succeeds, note the current date and time in your session notes so you can avoid repeating the step unnecessarily.
+- Confirm that `origin` still points to the primary repository with `git remote -v`; fix the remote immediately if it does not.
+
+## Avatar Retrieval Workflow
+- Use `scripts/fetch_avatar_assets.sh` (or an equivalent helper) before coding to download `avatars.json` and `README.md` from `https://qqrm.github.io/avatars-mcp/`. Record any fallback to legacy endpoints so we can fix the deployment.
+- The helper must try up to five times with a 5–10 second pause between attempts. Record any HTTP status codes or curl errors if every attempt fails.
+- When the downloads succeed, pick an avatar for the task, document the reason for the choice, and include this explanation in both the pull-request description and the final response to the user.
+
+## Development Process
+- Structure your work into small, focused commits with clear English messages.
+- After implementing changes, run every required check. At minimum, execute `cargo test --manifest-path sitegen/Cargo.toml` when that manifest exists, and add any extra commands that apply to the edited components.
+- Keep the working tree clean (`git status` should show no pending changes) before creating a pull request.
+
+## Pull Request Requirements
+- Ensure your branch is based on `main` and contains all necessary commits.
+- Create the GitHub pull request with `gh pr create --base main --fill` (or specify a title and description manually). If the command fails, retry and capture the exact error message for the final report.
+- Provide the pull-request URL in the final message to the user together with the avatar details.
+- When pull-request creation ultimately fails, document every attempted command and error message so reviewers understand the failure mode.

--- a/REPO_AGENTS.md
+++ b/REPO_AGENTS.md
@@ -3,14 +3,18 @@
 These instructions extend the base `Agents.md` rules for the entire repository.
 
 ## Mandatory Setup
-- Before modifying the repository, execute `./repo-setup.sh` from the repository root.
-- After the setup script succeeds, note the current date and time in your session notes so you can avoid repeating the step unnecessarily.
-- Confirm that `origin` still points to the primary repository with `git remote -v`; fix the remote immediately if it does not.
+- Before modifying the repository, execute `./repo-setup.sh` from the repository root. The script configures the canonical `origin` remote automatically when it is missing or incorrect.
+- After the setup script succeeds, record the current date and time in your session notes so future attempts know the environment is ready.
+- Double-check `git remote -v` once the script finishes; the `origin` remote must point to `https://github.com/qqrm/avatars-mcp.git`.
 
 ## Avatar Retrieval Workflow
 - Use `scripts/fetch_avatar_assets.sh` (or an equivalent helper) before coding to download `avatars.json` and `README.md` from `https://qqrm.github.io/avatars-mcp/`. Record any fallback to legacy endpoints so we can fix the deployment.
 - The helper must try up to five times with a 5–10 second pause between attempts. Record any HTTP status codes or curl errors if every attempt fails.
 - When the downloads succeed, pick an avatar for the task, document the reason for the choice, and include this explanation in both the pull-request description and the final response to the user.
+
+## Branch Management
+- Create a fresh, descriptive feature branch for every task before making any changes. Branch names must be in English, use hyphenated words, and describe the work (for example, `configure-remote-in-setup`).
+- The bootstrap branch named `work` is reserved; do **not** commit or push changes from it. Switch to your task-specific branch immediately after running the setup script.
 
 ## Development Process
 - Structure your work into small, focused commits with clear English messages.

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -70,7 +70,7 @@ You are a DevOps engineer. Your job is to:
 
 ## 4. Index Generation
 
-Tooling may iterate over `/avatars/`, parse YAML front matter, and produce `avatars/index.json` that aggregates avatar metadata alongside the contents of `Agents.md`. The resulting JSON is published on GitHub Pages and consumed by clients.
+Tooling may iterate over `/avatars/`, parse YAML front matter, and produce `avatars/index.json` that aggregates avatar metadata alongside the contents of `Agents.md`. The resulting JSON is published on GitHub Pages as both `avatars.json` and the legacy alias `avatars/index.json` and consumed by clients.
 
 Example index entry produced from the front matter above:
 
@@ -85,19 +85,19 @@ Example index entry produced from the front matter above:
 
 ## 5. API and MCP Access
 
-- **Catalog and base instructions:** `GET /avatars/index.json`
+- **Catalog and base instructions:** `GET /avatars.json` (the legacy alias `GET /avatars/index.json` remains available).
 - **Full avatar:** `GET /avatars/{id}.md`
 
 The optional Model Context Protocol server mirrors these resources over STDIO and implements:
 
-- `resources/list` – advertises `avatars/index.json` along with shared base instructions.
+- `resources/list` – advertises the catalog (`avatars.json`, also available at `avatars/index.json`) along with shared base instructions.
 - `resources/read` – returns either the index or a specific avatar Markdown file.
 
 ## 6. Extensibility and Tooling
 
 - Add new avatars by committing additional Markdown files under `/avatars/` with the required front matter.
 - Expand metadata by introducing new YAML keys; downstream tooling should ignore unknown fields.
-- A Rust CLI (typically under `src/`) can regenerate `avatars/index.json` via `cargo run --release`.
+- A Rust CLI (typically under `src/`) can regenerate `avatars/index.json` via `cargo run --release`; the GitHub Pages deployment publishes the result as both `avatars.json` and `avatars/index.json`.
 
 ## 7. Relationship to README
 

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -8,17 +8,52 @@ log() {
   printf '>> %s\n' "$*"
 }
 
-log "Running repository setup for avatars-mcp"
-log "Repository root: $SCRIPT_DIR"
+ensure_git_repo() {
+  if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    printf 'Error: repo-setup.sh must run inside a Git repository.\n' >&2
+    exit 1
+  fi
+}
 
-if git rev-parse --git-dir >/dev/null 2>&1; then
+ensure_origin_remote() {
+  local canonical_remote="https://github.com/qqrm/avatars-mcp.git"
+
+  if git remote get-url origin >/dev/null 2>&1; then
+    local current_url
+    current_url="$(git remote get-url origin)"
+    if [[ "$current_url" != "$canonical_remote" ]]; then
+      log "Updating origin remote from ${current_url} to ${canonical_remote}"
+      git remote set-url origin "$canonical_remote"
+    else
+      log "Origin remote already points to ${canonical_remote}"
+    fi
+  else
+    log "Configuring origin remote: ${canonical_remote}"
+    git remote add origin "$canonical_remote"
+  fi
+}
+
+print_status() {
   log "Current git status:"
   git status --short
   log "Configured remotes:"
   git remote -v
-else
-  printf 'Error: repo-setup.sh must run inside a Git repository.\n' >&2
-  exit 1
-fi
+}
+
+warn_branch_name() {
+  local current_branch
+  current_branch="$(git rev-parse --abbrev-ref HEAD)"
+  if [[ "$current_branch" == "work" ]]; then
+    printf 'Warning: Branch "work" is reserved for bootstrapping. Create a descriptive feature branch before making changes.\n' >&2
+  fi
+}
+
+log "Running repository setup for avatars-mcp"
+log "Repository root: $SCRIPT_DIR"
+
+ensure_git_repo
+ensure_origin_remote
+print_status
+warn_branch_name
 
 log "Setup completed at $(date --iso-8601=seconds)"

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+log() {
+  printf '>> %s\n' "$*"
+}
+
+log "Running repository setup for avatars-mcp"
+log "Repository root: $SCRIPT_DIR"
+
+if git rev-parse --git-dir >/dev/null 2>&1; then
+  log "Current git status:"
+  git status --short
+  log "Configured remotes:"
+  git remote -v
+else
+  printf 'Error: repo-setup.sh must run inside a Git repository.\n' >&2
+  exit 1
+fi
+
+log "Setup completed at $(date --iso-8601=seconds)"

--- a/scripts/fetch_avatar_assets.sh
+++ b/scripts/fetch_avatar_assets.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_URL="https://qqrm.github.io/avatars-mcp"
+AVATAR_JSON="${1:-/tmp/avatars.json}"
+GUIDELINES_MD="${2:-/tmp/avatar_guidelines.md}"
+MAX_ATTEMPTS=5
+SLEEP_SECONDS=10
+
+PRIMARY_CATALOG_URL="${BASE_URL}/avatars.json"
+LEGACY_CATALOG_URL="${BASE_URL}/avatars/index.json"
+GUIDELINES_URL="${BASE_URL}/README.md"
+
+FETCH_ERROR=""
+CATALOG_SOURCE=""
+CATALOG_WARNING=""
+
+fetch() {
+  local url="$1"
+  local destination="$2"
+
+  local http_code
+  http_code=$(curl --silent --show-error --location --output "$destination" --write-out '%{http_code}' "$url" || true)
+  local exit_code=$?
+
+  if [[ $exit_code -ne 0 ]]; then
+    rm -f "$destination"
+    local code_msg=""
+    if [[ $http_code =~ ^[0-9]{3}$ && $http_code != "000" ]]; then
+      code_msg=" (HTTP ${http_code})"
+    fi
+    FETCH_ERROR="curl exit ${exit_code}${code_msg} (${url})"
+    return 1
+  fi
+
+  if [[ ! $http_code =~ ^[0-9]{3}$ ]]; then
+    FETCH_ERROR="Unexpected response code '${http_code}' (${url})"
+    return 1
+  fi
+
+  if [[ $http_code -lt 200 || $http_code -ge 300 ]]; then
+    rm -f "$destination"
+    FETCH_ERROR="HTTP ${http_code} (${url})"
+    return 1
+  fi
+
+  FETCH_ERROR=""
+  return 0
+}
+
+download_catalog() {
+  if fetch "$PRIMARY_CATALOG_URL" "$AVATAR_JSON"; then
+    CATALOG_SOURCE="primary"
+    CATALOG_WARNING=""
+    return 0
+  fi
+
+  local primary_error="$FETCH_ERROR"
+
+  if fetch "$LEGACY_CATALOG_URL" "$AVATAR_JSON"; then
+    CATALOG_SOURCE="legacy"
+    CATALOG_WARNING="Primary catalog unavailable: ${primary_error}"
+    return 0
+  fi
+
+  local legacy_error="$FETCH_ERROR"
+  FETCH_ERROR="Primary catalog unavailable: ${primary_error}; legacy catalog unavailable: ${legacy_error}"
+  CATALOG_SOURCE=""
+  CATALOG_WARNING=""
+  return 1
+}
+
+download_guidelines() {
+  if fetch "$GUIDELINES_URL" "$GUIDELINES_MD"; then
+    return 0
+  fi
+
+  FETCH_ERROR="Guidelines download failed: ${FETCH_ERROR}"
+  return 1
+}
+
+attempt=1
+while (( attempt <= MAX_ATTEMPTS )); do
+  if download_catalog && download_guidelines; then
+    if [[ -n "$CATALOG_WARNING" ]]; then
+      printf '%s\n' "$CATALOG_WARNING" >&2
+    fi
+    if [[ "$CATALOG_SOURCE" == "legacy" ]]; then
+      printf 'Fetched avatar data on attempt %d using the legacy endpoint.\n' "$attempt"
+    else
+      printf 'Fetched avatar data on attempt %d.\n' "$attempt"
+    fi
+    exit 0
+  fi
+
+  if (( attempt < MAX_ATTEMPTS )); then
+    printf 'Attempt %d failed: %s. Retrying in %d seconds...\n' "$attempt" "$FETCH_ERROR" "$SLEEP_SECONDS" >&2
+  else
+    printf 'Attempt %d failed: %s.\n' "$attempt" "$FETCH_ERROR" >&2
+  fi
+  attempt=$(( attempt + 1 ))
+  if (( attempt <= MAX_ATTEMPTS )); then
+    sleep "$SLEEP_SECONDS"
+  fi
+  FETCH_ERROR=""
+  CATALOG_SOURCE=""
+  CATALOG_WARNING=""
+  rm -f "$AVATAR_JSON" "$GUIDELINES_MD"
+done
+
+printf 'Failed to download avatar resources after %d attempts.\n' "$MAX_ATTEMPTS" >&2
+exit 1


### PR DESCRIPTION
## Summary
- ensure repo-setup.sh configures the canonical origin remote and warns about the bootstrap branch
- expand the repository agent instructions with canonical remote verification and branch naming guidance

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
