### PR TITLE
Move remote configuration into repo setup helper

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,10 +32,10 @@ jobs:
       - run: |
           mkdir -p public/avatars
           cp -r avatars/* public/avatars/
-          cp BASE_AGENTS.md INSTRUCTIONS.md mcp.json public/
+          cp Agents.md INSTRUCTIONS.md mcp.json public/
           cp avatars/index.json public/index.json
           {
-            cat BASE_AGENTS.md
+            cat Agents.md
             echo
             echo "## Avatars"
             for f in avatars/*.md; do

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Repository-specific initialization for avatars-mcp
+# Configures the writable origin remote expected by repository tooling.
+
+set -Eeuo pipefail
+
+log() { printf '>> %s\n' "$*"; }
+
+die() { printf '❌ %s\n' "$*" >&2; exit 1; }
+
+REMOTE_URL="${REPO_REMOTE_URL:-https://github.com/qqrm/avatars-mcp.git}"
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  die "Not inside a Git repository"
+fi
+
+current_remote="$(git remote get-url origin 2>/dev/null || true)"
+if [[ -z "$current_remote" ]]; then
+  git remote add origin "$REMOTE_URL"
+  log "git remote origin added: $REMOTE_URL"
+elif [[ "$current_remote" != "$REMOTE_URL" ]]; then
+  git remote set-url origin "$REMOTE_URL"
+  log "git remote origin updated: $REMOTE_URL"
+else
+  log "git remote origin already set to $REMOTE_URL"
+fi
+
+git fetch origin --tags --quiet
+log "git remote origin fetched"


### PR DESCRIPTION
## Summary
- remove git remote logic from the shared setup.sh bootstrapper
- add repo-setup.sh so the avatars repository configures its origin locally
- have the repo-specific script fetch the newly configured remote

## Testing
- bash -n setup.sh
- bash -n repo-setup.sh
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68cb93228f7883329085fac92e0a1db0