### PR TITLE
Clarify global branch management guidance

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -18,6 +18,9 @@ These guidelines apply to every avatar in this repository.
 
 ## Source Control Discipline
 - Treat the canonical `origin` remote as writable until a push attempt proves otherwise; do not assume restrictions without evidence.
+- Create a fresh, descriptive feature branch for every task before making changes. Branch names must be in English, use hyphenated words, and describe the work (for example, `configure-remote-in-setup`).
+- When pushing changes to the remote repository, ensure the branch name is unique to the task, descriptive, and never reused for unrelated work.
+- The bootstrap branch named `work` is reserved; do **not** commit or push changes from it, and never create or push a branch named `WORK`. Switch to your task-specific branch immediately after running the setup script.
 - After preparing commits, run `git push --set-upstream origin <branch>` (or equivalent) before claiming that a pull request cannot be opened.
 - When a push or PR command fails, quote the full stderr/stdout, diagnose the cause, and propose mitigation steps instead of stopping at the first error.
 

--- a/REPO_AGENTS.md
+++ b/REPO_AGENTS.md
@@ -22,7 +22,8 @@ These instructions extend the base `Agents.md` rules for the entire repository.
 
 ## Branch Management
 - Create a fresh, descriptive feature branch for every task before making any changes. Branch names must be in English, use hyphenated words, and describe the work (for example, `configure-remote-in-setup`).
-- The bootstrap branch named `work` is reserved; do **not** commit or push changes from it. Switch to your task-specific branch immediately after running the setup script.
+- When pushing changes to the remote repository, ensure the branch name is unique, descriptive, and not reused across unrelated tasks.
+- The bootstrap branch named `work` is reserved; do **not** commit or push changes from it, and never create or push a branch named `WORK`. Switch to your task-specific branch immediately after running the setup script.
 - Push the freshly created branch (`git push --set-upstream origin <branch>`) to verify remote access before making extensive edits. Quote the exact failure output if the push is rejected.
 
 ## Development Process


### PR DESCRIPTION
## Summary
- Extend the global source control guidance to require fresh, descriptive feature branches for every task.
- Instruct all agents to push uniquely named branches and forbid using the reserved name `WORK` for remote work.

## Testing
- Not run (documentation only)

## Avatar
- Software Architect — codifying repo-agnostic branch management policy for the organization.
