### PR TITLE
Move universal avatar workflow to global guide

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,11 +32,11 @@ jobs:
       - run: |
           mkdir -p public/avatars
           cp -r avatars/* public/avatars/
-          cp Agents.md INSTRUCTIONS.md README.md mcp.json public/
+          cp AGENTS.md INSTRUCTIONS.md README.md mcp.json public/
           cp avatars/catalog.json public/index.json
           cp avatars/catalog.json public/avatars.json
           {
-            cat Agents.md
+            cat AGENTS.md
             echo
             echo "## Avatars"
             for f in avatars/*.md; do
@@ -73,7 +73,7 @@ jobs:
           paths=(
             "index.json"
             "avatars.json"
-            "Agents.md"
+            "AGENTS.md"
             "INSTRUCTIONS.md"
             "README.md"
             "mcp.json"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,9 @@ These guidelines apply to every avatar in this repository.
 
 ## Avatars
 - Use the MCP server at `https://qqrm.github.io/avatars-mcp/` to fetch avatars and base instructions.
+- Before starting implementation work, run the repository-provided helper (for example, `scripts/fetch_avatar_assets.sh`) to download the latest avatar catalog and README. Retry failures up to five times with short delays and capture the HTTP error details if all attempts fail.
+- Select a non-default avatar that matches the task context, document why it fits, and include this rationale both in the pull-request description and in the final response to the user.
+- When automated downloads are impossible, note every attempt, escalate the outage, and choose the closest avatar based on cached knowledge while clearly labeling the fallback.
 
 ## Rust Documentation Servers
 - `setup.sh` installs the `crates-mcp` server via `cargo-binstall` with a source fallback.
@@ -98,6 +101,9 @@ These guidelines apply to every avatar in this repository.
 - Use the [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) pipelines for Rust projects; they are our required modern standard.
 - Treat GitHub workflows as first-class code: keep them under version control, review every change, and follow the CI guidelines below.
 - After completing a task, verify that the current branch's HEAD matches `origin/main`; if `origin/main` has advanced, restart the task from the latest commit.
+
+## Rust Validation
+- For Rust repositories, run `cargo test` from the workspace root before opening a pull request—even when only documentation changes. Record failures verbatim and resolve them or escalate with proposed mitigation.
 
 ## Pre-commit Checks
 Install tools if needed:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ These guidelines apply to every avatar in this repository.
 - Default to initiative—do not wait for the user to request obvious next steps, and avoid dwelling on limitations unless they block progress.
 - Validate assumptions with evidence: inspect the workspace, run discovery commands, and confirm tool availability instead of guessing.
 - When instructions conflict, surface the conflict, pick the best production-ready approach, and document the reasoning.
+- Own the task end-to-end: investigate, plan, implement, validate, and report with minimal prompting.
+- Escalate blockers quickly with actionable detail rather than waiting for new guidance.
 
 ## Tooling Expectations
 - Assume the local toolchain is ready for real-world development: `git`, `gh`, language toolchains, formatters, linters, and test runners.
@@ -19,11 +21,19 @@ These guidelines apply to every avatar in this repository.
 ## Source Control Discipline
 - Treat the canonical `origin` remote as writable until a push attempt proves otherwise; do not assume restrictions without evidence.
 - Create a fresh, descriptive feature branch for every task before making changes. Branch names must be in English, use hyphenated words, and describe the work (for example, `configure-remote-in-setup`).
-- When pushing changes to the remote repository, ensure the branch name is unique to the task, descriptive, and never reused for unrelated work.
+- Keep branch names unique to the task. When the user keeps the task active across multiple iterations in the same Code environment, stay on the existing branch: fetch the latest `origin/main`, rebase or merge **before every response**, and share the active pull-request URL alongside your status so reviewers can follow along.
+- Keep the task branch alive until its pull request merges; do not delete, rename, or reset it between updates, and push every new commit to the same remote branch.
 - The bootstrap branch named `work` is reserved; do **not** commit or push changes from it, and never create or push a branch named `WORK`. Switch to your task-specific branch immediately after running the setup script.
 - After preparing commits, run `git push --set-upstream origin <branch>` (or equivalent) before claiming that a pull request cannot be opened.
 - Before reporting completion, confirm the remote branch contains the latest commits (for example, compare `git log origin/<branch>` with `git log HEAD`) so reviewers see the final changes.
 - When a push or PR command fails, quote the full stderr/stdout, diagnose the cause, and propose mitigation steps instead of stopping at the first error.
+
+## Execution Discipline
+- Structure your work into small, focused commits with clear English messages so reviewers can follow each step.
+- Keep the working tree clean before requesting review or reporting status—stage intentional changes, revert stragglers, and ensure `git status` is empty when you announce completion.
+- Run every required check before committing. Default to the full test suite for the components you touched and document any skipped command together with the justification.
+- Use the `gh` CLI (or equivalent tooling) to inspect open pull requests, checks, and workflow runs when verification on GitHub is necessary; record the exact commands and outcomes.
+- Do not report that pushes or pull-request creation are impossible unless you have just run the relevant command and collected its stderr/stdout for your notes.
 
 ## Avatars
 - Use the MCP server at `https://qqrm.github.io/avatars-mcp/` to fetch avatars and base instructions.
@@ -56,7 +66,7 @@ These guidelines apply to every avatar in this repository.
 - Stay inquisitive: when information is missing, ask focused follow-up questions or perform targeted experiments to close the gap before proceeding.
 
 ## Instruction Management
-- This root `AGENTS.md` is fetched from a remote server during container initialization. After initialization, do not edit or commit this file.
+- This root `AGENTS.md` is fetched from a remote server during container initialization. Update it only when you intentionally change the global rules; otherwise leave it untouched.
 - Repository-specific instructions may appear in `REPO_AGENTS.md`. If this file is absent, assume no extra instructions.
 - Additional `AGENTS.md` files may appear in subdirectories; follow their instructions within their scope.
 - Keep `AGENTS.md` entries in English.

--- a/AUTO_CONFLICT_STRATEGY.md
+++ b/AUTO_CONFLICT_STRATEGY.md
@@ -10,7 +10,7 @@ This document defines the production workflow the automation agent must follow t
    git config --global pull.rebase true
    ```
 2. Honour the repository merge policies committed in `.gitattributes`. They guarantee predictable merges for generated assets (`*.snap`, `*.svg`, `target/**`, `Cargo.lock`) and enforce LF line endings for Rust sources.
-3. Always work on a dedicated feature branch. Branch names use English, hyphenated words (`feature-name-improvement`).
+3. Always work on a dedicated feature branch, keeping it active across iterations of the same task until the pull request merges. Branch names use English, hyphenated words (`feature-name-improvement`).
 
 ## 2. Required tooling scripts
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Run `./setup.sh` to install the optional MCP servers referenced by `mcp.json`; i
 
 - **Specification:** See [`SPECIFICATION.md`](SPECIFICATION.md) for the canonical directory layout, avatar schema, and API details.
 - **Avatars:** Individual prompts live in [`/avatars/`](avatars/); each file targets a single role.
-- **Base instructions:** Shared guidance for all avatars resides in [`Agents.md`](Agents.md).
+- **Base instructions:** Shared guidance for all avatars resides in [`AGENTS.md`](AGENTS.md).
 - **HTTP quick reference:** [`INSTRUCTIONS.md`](INSTRUCTIONS.md) summarizes the published endpoints external clients call.
 
 ## Shared Files for External Consumers
 
 External clients rely on a small set of shared files published alongside the avatars:
 
-- [`Agents.md`](Agents.md) — the baseline instructions served to external agents and bundled into the published `avatars.json` catalog.
+- [`AGENTS.md`](AGENTS.md) — the baseline instructions served to external agents and bundled into the published `avatars.json` catalog.
 - [`INSTRUCTIONS.md`](INSTRUCTIONS.md) — a condensed description of the HTTP API exposed via GitHub Pages.
 - [`mcp.json`](mcp.json) — the default Model Context Protocol manifest that activates these resources in compatible clients.
 
@@ -48,7 +48,7 @@ automates only the dependencies it needs while keeping the filename consistent.
 
 ## Tooling
 
-A Rust CLI located in [`src/`](src) regenerates the catalog stored at [`avatars/catalog.json`](avatars/catalog.json) by parsing the avatar front matter and bundling `Agents.md`. The GitHub Pages deployment exposes this catalog as `avatars.json`. Build the index with:
+A Rust CLI located in [`src/`](src) regenerates the catalog stored at [`avatars/catalog.json`](avatars/catalog.json) by parsing the avatar front matter and bundling `AGENTS.md`. The GitHub Pages deployment exposes this catalog as `avatars.json`. Build the index with:
 
 ```bash
 cargo run --release

--- a/REPO_AGENTS.md
+++ b/REPO_AGENTS.md
@@ -9,15 +9,5 @@ These instructions extend the base `AGENTS.md` rules for the entire repository.
 - Run `gh auth status` immediately after setup to confirm credentials are valid; capture the full output when authentication fails.
 - If any setup step fails, capture the full command output, diagnose the cause, and propose a fix or workaround.
 
-## Avatar Retrieval Workflow
-- Use `scripts/fetch_avatar_assets.sh` (or an equivalent helper) before coding to download `avatars.json` and `README.md` from `https://qqrm.github.io/avatars-mcp/`. Capture detailed HTTP errors whenever a download fails so outages can be triaged quickly.
-- The helper must try up to five times with a 5–10 second pause between attempts. Record any HTTP status codes or curl errors if every attempt fails.
-- When the downloads succeed, pick an avatar for the task, document the reason for the choice, and include this explanation in both the pull-request description and the final response to the user.
-- If asset retrieval is impossible, log the attempts, escalate the outage, and continue with the best-matching avatar based on cached knowledge.
-
-## Repository Validation
-- Run the Rust test suite from the repository root (`cargo test`) before opening a pull request so the CLI that publishes the avatar catalog remains healthy.
-- Capture the output of any failing command and address the problem before proceeding. If a failure is outside your control, document the exact logs and escalate it.
-
 ## Branch Management and Pull Requests
 This repository relies on the global branching, pull-request, and conflict-resolution process defined in `AGENTS.md` (including `AUTO_CONFLICT_STRATEGY.md`). Follow those universal rules here, then apply the repository-specific setup and automation practices described above.

--- a/REPO_AGENTS.md
+++ b/REPO_AGENTS.md
@@ -1,11 +1,6 @@
 # Repository Agent Instructions
 
-These instructions extend the base `Agents.md` rules for the entire repository.
-
-## Mindset
-- Assume you are contributing to a production service. Optimise for reliable delivery, not experimentation.
-- Own the task end-to-end: investigate, plan, implement, validate, and report with minimal prompting.
-- Escalate blockers with actionable detail instead of waiting for new guidance.
+These instructions extend the base `AGENTS.md` rules for the entire repository.
 
 ## Mandatory Setup
 - Before modifying the repository, execute `./repo-setup.sh` from the repository root. The script configures the canonical `origin` remote automatically when it is missing or incorrect.
@@ -20,22 +15,9 @@ These instructions extend the base `Agents.md` rules for the entire repository.
 - When the downloads succeed, pick an avatar for the task, document the reason for the choice, and include this explanation in both the pull-request description and the final response to the user.
 - If asset retrieval is impossible, log the attempts, escalate the outage, and continue with the best-matching avatar based on cached knowledge.
 
-## Branch Management
-- Create a fresh, descriptive feature branch for every task before making any changes. Branch names must be in English, use hyphenated words, and describe the work (for example, `configure-remote-in-setup`).
-- When pushing changes to the remote repository, ensure the branch name is unique, descriptive, and not reused across unrelated tasks.
-- The bootstrap branch named `work` is reserved; do **not** commit or push changes from it, and never create or push a branch named `WORK`. Switch to your task-specific branch immediately after running the setup script.
-- Push the freshly created branch (`git push --set-upstream origin <branch>`) to verify remote access before making extensive edits. Quote the exact failure output if the push is rejected.
+## Repository Validation
+- Run the Rust test suite from the repository root (`cargo test`) before opening a pull request so the CLI that publishes the avatar catalog remains healthy.
+- Capture the output of any failing command and address the problem before proceeding. If a failure is outside your control, document the exact logs and escalate it.
 
-## Development Process
-- Structure your work into small, focused commits with clear English messages.
-- After implementing changes, run every required check. At minimum, execute `cargo test --manifest-path sitegen/Cargo.toml` when that manifest exists, and add any extra commands that apply to the edited components. Capture and address failures instead of skipping them.
-- Keep the working tree clean (`git status` should show no pending changes) before creating a pull request.
-- Use the `gh` CLI to inspect open pull requests, checks, and workflow runs when verification on GitHub is necessary; report exact commands and outcomes.
-- Do not report that pushes or pull-request creation are impossible unless you have just run the relevant command and collected its stderr/stdout for your notes.
-
-## Pull Request Requirements
-- Ensure your branch is based on `main` and contains all necessary commits.
-- Create the GitHub pull request with `gh pr create --base main --fill` (or specify a title and description manually). If the command fails, retry and capture the exact error message for the final report.
-- Provide the pull-request URL in the final message to the user together with the avatar details.
-- When pull-request creation ultimately fails, document every attempted command and error message so reviewers understand the failure mode.
-- Push the latest commits before each `gh pr create` attempt so the remote branch reflects your changes; include the command output in the final report when issues persist.
+## Branch Management and Pull Requests
+This repository relies on the global branching, pull-request, and conflict-resolution process defined in `AGENTS.md` (including `AUTO_CONFLICT_STRATEGY.md`). Follow those universal rules here, then apply the repository-specific setup and automation practices described above.

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -19,7 +19,7 @@ mcp.json
 ```
 
 - `/avatars/` stores every avatar Markdown file.
-- `Agents.md` contains shared base instructions bundled into the index.
+- `AGENTS.md` contains shared base instructions bundled into the index.
 - `src/` or `generator.rs` may host tooling that produces `avatars/catalog.json`.
 
 ## 3. Avatar File Format
@@ -70,7 +70,7 @@ You are a DevOps engineer. Your job is to:
 
 ## 4. Index Generation
 
-Tooling may iterate over `/avatars/`, parse YAML front matter, and produce `avatars/catalog.json` that aggregates avatar metadata alongside the contents of `Agents.md`. The resulting JSON is published on GitHub Pages as `avatars.json` and consumed by clients.
+Tooling may iterate over `/avatars/`, parse YAML front matter, and produce `avatars/catalog.json` that aggregates avatar metadata alongside the contents of `AGENTS.md`. The resulting JSON is published on GitHub Pages as `avatars.json` and consumed by clients.
 
 Example index entry produced from the front matter above:
 

--- a/avatars/catalog.json
+++ b/avatars/catalog.json
@@ -1,5 +1,5 @@
 {
-  "base_uri": "Agents.md",
+  "base_uri": "AGENTS.md",
   "avatars": [
     {
       "id": "tester",

--- a/setup.sh
+++ b/setup.sh
@@ -52,12 +52,12 @@ else
   log "mcp.json already exists"
 fi
 
-# refresh Agents.md from the remote server
-agents_url="${MCP_BASE_URL%/}/Agents.md"
-if curl -fsSL "$agents_url" -o Agents.md; then
-  log "Agents.md refreshed from $agents_url"
+# refresh AGENTS.md from the remote server
+agents_url="${MCP_BASE_URL%/}/AGENTS.md"
+if curl -fsSL "$agents_url" -o AGENTS.md; then
+  log "AGENTS.md refreshed from $agents_url"
 else
-  log "Agents.md unavailable at $agents_url"
+  log "AGENTS.md unavailable at $agents_url"
 fi
 
 # gh installation if missing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,11 +165,11 @@ mod tests {
                 avatars.join("TWO.md"),
                 "---\nid: two\nname: Two\n---\nbody\n",
             )?;
-            fs::write(root.join("Agents.md"), "Base instructions\n")?;
+            fs::write(root.join("AGENTS.md"), "Base instructions\n")?;
 
-            let index = generate_index(&avatars, &root.join("Agents.md"))?;
+            let index = generate_index(&avatars, &root.join("AGENTS.md"))?;
             assert_eq!(index.avatars.len(), 2);
-            assert_eq!(index.base_uri, "Agents.md");
+            assert_eq!(index.base_uri, "AGENTS.md");
 
             let first = index.avatars.iter().find(|m| m.meta.id == "one").unwrap();
             assert_eq!(first.meta.name, "One");

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let avatars_dir = Path::new("avatars");
-    let base_path = Path::new("Agents.md");
+    let base_path = Path::new("AGENTS.md");
     let index = generate_index(avatars_dir, base_path)?;
     println!("Index generated with {} avatars", index.avatars.len());
     Ok(())


### PR DESCRIPTION
## Avatar
- Rust Tech Lead — chosen to realign cross-repository process documentation and enforce disciplined execution.

## Summary
- promote the avatar download workflow and selection requirements to AGENTS.md so every repository gets the same guidance
- require cargo test from the workspace root for all Rust projects and reference it from the global instructions
- trim REPO_AGENTS.md to the setup steps unique to avatars-mcp

## Testing
- cargo test