### PR TITLE
Restructure Rust tooling into a workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,19 +18,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+name = "avatars-cli"
+version = "0.1.0"
+dependencies = [
+ "avatars-core",
+ "serde_json",
+]
 
 [[package]]
-name = "avatars_generator"
+name = "avatars-core"
 version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
+]
+
+[[package]]
+name = "avatars-mcp"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
  "tokio",
 ]
 
@@ -153,16 +162,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
-name = "lock_api"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,29 +203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,15 +233,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,12 +256,6 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -342,35 +303,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
-dependencies = [
- "libc",
- "windows-sys",
-]
 
 [[package]]
 name = "syn"
@@ -407,13 +343,9 @@ dependencies = [
  "io-uring",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "slab",
- "socket2",
  "tokio-macros",
- "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,7 @@
-[package]
-name = "avatars_generator"
-version = "0.1.0"
-edition = "2024"
-default-run = "avatars_generator"
-
-[dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9"
-serde_json = "1.0"
-tokio = { version = "1", features = ["full"] }
-
-[[bin]]
-name = "mcp_server"
-path = "src/server.rs"
-
-[dev-dependencies]
-tempfile = "3"
+[workspace]
+members = [
+    "crates/core",
+    "crates/cli",
+    "crates/mcp",
+]
+resolver = "2"

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -6,5 +6,6 @@ The avatar API is available at:
 https://qqrm.github.io/avatars-mcp/
 ```
 
-- `GET /avatars.json` — retrieve base instructions and the avatar catalog.
+- `GET /avatars.json` — retrieve base instructions (under `base_instructions`) and the avatar catalog.
+- `GET /AGENTS.md` — fetch the shared baseline instructions directly.
 - `GET /avatars/{id}.md` — retrieve the complete descriptor for the avatar with the given `id`.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Run `./setup.sh` to install the optional MCP servers referenced by `mcp.json`; i
 
 External clients rely on a small set of shared files published alongside the avatars:
 
-- [`AGENTS.md`](AGENTS.md) — the baseline instructions served to external agents and bundled into the published `avatars.json` catalog.
+- [`AGENTS.md`](AGENTS.md) — the baseline instructions served to external agents, embedded in and linked from the published `avatars.json` catalog.
 - [`INSTRUCTIONS.md`](INSTRUCTIONS.md) — a condensed description of the HTTP API exposed via GitHub Pages.
 - [`mcp.json`](mcp.json) — the default Model Context Protocol manifest that activates these resources in compatible clients.
 
@@ -40,19 +40,18 @@ Repository tooling keeps these artifacts in sync for local use:
 
 ## Repository-Specific Setup Script
 
-Every repository in this ecosystem can ship its own local setup helper tailored to its automation requirements under the shared
-name `repo-setup.sh`. The [`setup.sh`](setup.sh) script in this repository provisions GitHub CLI authentication,
-installs required Rust tooling, refreshes the published MCP assets directly, and then runs `repo-setup.sh`
-if it exists. When working in other repositories, expect their `repo-setup.sh` contents to diverge—each project documents and
-automates only the dependencies it needs while keeping the filename consistent.
+Every repository in this ecosystem can ship its own local setup helper tailored to its automation requirements under the shared name `repo-setup.sh`. The [`setup.sh`](setup.sh) script in this repository provisions GitHub CLI authentication, installs required Rust tooling, refreshes the published MCP assets directly, and then runs `repo-setup.sh` if it exists. When working in other repositories, expect their `repo-setup.sh` contents to diverge—each project documents and automates only the dependencies it needs while keeping the filename consistent.
 
 ## Tooling
 
-A Rust CLI located in [`src/`](src) regenerates the catalog stored at [`avatars/catalog.json`](avatars/catalog.json) by parsing the avatar front matter and bundling `AGENTS.md`. The GitHub Pages deployment exposes this catalog as `avatars.json`. Build the index with:
+A Rust workspace under [`/crates/`](crates/) regenerates the catalog stored at [`avatars/catalog.json`](avatars/catalog.json) by parsing the avatar front matter and bundling both the base instructions and avatar metadata. The GitHub Pages deployment exposes this catalog as `avatars.json`. Build the index with:
 
 ```bash
-cargo run --release
+cargo run -p avatars-cli --release
 ```
+
+The auxiliary binary `index_uris` (packaged with the CLI crate) lists the avatar URIs from an existing catalog to simplify pipeline scripting.
+
 ### GitHub Pages Publishing
 
 The [GitHub Pages workflow](.github/workflows/pages.yml) rebuilds the avatar catalog, publishes it as `avatars.json` (with a duplicate `index.json` for convenience), and syncs the `avatars/` directory whenever updates land on `main` or release tags. Refer to the workflow file for the complete automation steps.
@@ -65,11 +64,11 @@ The latest version of the avatar API is served from GitHub Pages at:
 https://qqrm.github.io/avatars-mcp/
 ```
 
-You can browse individual avatar files or fetch the catalog directly from `avatars.json`, for example:
+- `GET /avatars.json` — retrieve the catalog along with the embedded `base_instructions` payload.
+- `GET /AGENTS.md` — download the shared baseline instructions directly (mirrors the `base_instructions` field).
+- `GET /avatars/{id}.md` — retrieve the complete descriptor for the avatar with the given `id`.
 
-```text
-https://qqrm.github.io/avatars-mcp/avatars.json
-```
+Clients should fetch both the catalog and `AGENTS.md` to ensure they stay in sync with the published baseline guidance, even though bootstrap scripts normally install the Markdown locally.
 
 Continuous integration pipelines lint and test the Rust tooling (`cargo fmt`, `cargo clippy`, and `cargo test`). GitHub Pages deployments rebuild the catalog from `main` and publish it to `https://qqrm.github.io/avatars-mcp/avatars.json` alongside the avatar Markdown files.
 

--- a/avatars/catalog.json
+++ b/avatars/catalog.json
@@ -1,32 +1,19 @@
 {
   "base_uri": "AGENTS.md",
+  "base_instructions": "# Base Agent Instructions\n\nThese guidelines apply to every avatar in this repository.\n\n## Critical Checklist\n- Run `./repo-setup.sh` (when provided) as soon as the repository is available, then confirm `git remote -v` points to the canonical `origin` and that `gh auth status` succeeds.\n- Switch off the bootstrap `work` branch immediately, create a descriptive English feature branch, and never create or push a branch named `WORK`.\n- Treat every assignment as production work: plan the solution, implement it to a high standard, and keep the working tree clean.\n- Retrieve the avatar catalog via the MCP server's REST API, pick a non-default avatar that fits the task, and explain the choice in both the pull-request description and the final user summary.\n- Use the `gh` CLI for pull requests—push your branch, run `gh pr create`, and wait for all mandatory GitHub Actions checks to pass (`gh pr checks` or UI) before declaring the task complete. Capture full command output for any failure.\n- Run the required validation suite (`cargo fmt`, `cargo check`, `cargo clippy`, `cargo test`, `cargo machete`, etc.) before committing and again before wrapping up. Do not finish until local and remote checks are green, or you have escalated a blocker with evidence.\n\n## Engineering Mindset\n- Operate like a senior engineer: analyse the problem space, decide on a plan, execute decisively, and justify trade-offs.\n- Validate assumptions with evidence—inspect the workspace, run discovery commands, and confirm tool availability instead of guessing.\n- Surface conflicting instructions, choose the most production-ready resolution, and document the reasoning.\n- Escalate blockers quickly with actionable detail rather than waiting for new guidance.\n\n## Planning and Strategy\n- Review every applicable `AGENTS.md` file before modifying code.\n- Consult repository documentation such as `ARCHITECTURE.md`, `SPECIFICATION.md`, or READMEs whenever they exist.\n- Draft a concise plan for multi-step work, update it as facts change, and communicate deviations with rationale.\n- Confirm that each user request belongs to this repository; request clarification when scope is uncertain.\n- Stay inquisitive—close knowledge gaps by asking focused follow-up questions or running targeted experiments.\n\n## Tooling and Environment\n- Assume the local toolchain is ready for real-world development: `git`, `gh`, language toolchains, formatters, linters, and test runners.\n- Prefer command-line tooling and automate repetitive steps to keep workflows reproducible.\n- Confirm `gh auth status`, `git remote -v`, and other environment checks early in each task so you understand what is available.\n- When a required tool is unavailable, record the failure, suggest remediation, and continue with alternative plans when feasible.\n- Keep repository automation in `repo-setup.sh` and author helpers in POSIX shell. The shared `setup.sh` bootstrapper runs `repo-setup.sh` automatically.\n- If a `local_setup.sh` script exists, execute it before starting any task.\n- `setup.sh` installs the `crates-mcp` server via `cargo-binstall` with a source fallback, and `mcp.json` enables it by default.\n- Available local MCP servers include `crates-mcp` (e.g., `{ \"tool\": \"search_crates\", \"query\": \"http client\" }`).\n\n## Source Control and Branching\n- Treat the canonical `origin` remote as writable until a push attempt proves otherwise; do not assume restrictions without evidence.\n- Create a fresh hyphenated English feature branch for every task. When a task spans multiple sessions, stay on the same branch, fetch `origin/main`, and rebase or merge **before every response**.\n- Keep the task branch alive until its pull request merges—never delete, rename, or reset it mid-task, and push every new commit to the same remote branch.\n- After preparing commits, run `git push --set-upstream origin <branch>` (or equivalent) before claiming that a pull request cannot be opened.\n- Before reporting completion, confirm that `origin/<branch>` contains the latest commits (compare with `git log HEAD`).\n- When a push or PR command fails, quote the full stderr/stdout, diagnose the cause, and propose mitigation steps instead of stopping at the first error.\n- Maintain small, focused commits with clear English messages so reviewers can follow each step.\n- Keep the working tree clean before requesting review or reporting status—stage intentional changes, revert stragglers, and ensure `git status` is empty when you finish.\n\n## Development Workflow\n- Treat user requests as complete tasks and deliver full pull-request solutions.\n- Run every required check before committing. Default to the full test suite for the components you touched and document any skipped command with justification.\n- Use automation to inspect GitHub state: rely on `gh` for pull requests, issue queries, workflow inspection, and to monitor checks.\n- Use the `gh` CLI to create and manage pull requests whenever possible so CI runs early. The CLI is authenticated during container initialization and ready for immediate use.\n- Ensure a writable `origin` remote is configured before invoking `gh pr create`; follow repository README guidance when the remote is missing.\n- When network access or permissions block pull-request creation, record the attempted commands, explain the impact, and continue working toward the deliverable.\n- The evaluation `make_pr` tool only submits metadata; it never replaces a real GitHub pull request.\n- Remove dead code rather than suppressing warnings; feature-gate unused code when necessary.\n- Write tests for new functionality and resolve reported problems.\n\n## Avatars\n- Use the MCP server at `https://qqrm.github.io/avatars-mcp/` to fetch avatars and base instructions.\n- Use the MCP server's REST API to inspect the latest avatar catalog and README information as needed. Record HTTP errors and retry transient failures up to five times before escalating.\n- Select a non-default avatar that matches the task context, document why it fits, and include this rationale both in the pull-request description and in the final response to the user.\n- When automated downloads are impossible, note every attempt, escalate the outage, and choose the closest avatar based on cached knowledge while clearly labeling the fallback.\n- Switch avatars through the MCP server as needed for sub-tasks (e.g., Senior, Architect, Tester, Analyst) and list every avatar used when summarising work.\n\n## Testing and Validation\n- For Rust repositories, run `cargo test` from the workspace root before opening a pull request—even when only documentation changes. Record failures verbatim and resolve them or escalate with proposed mitigation.\n- Install tooling as needed (`rustup component add clippy rustfmt`).\n- Standard validation sequence:\n  ```bash\n  cargo fmt --all\n  cargo check --tests --benches\n  cargo clippy --all-targets --all-features -- -D warnings\n  cargo test\n  cargo machete            # if available\n  ```\n- Skip build-heavy checks only when changes affect documentation or Markdown files, and note the justification in your report.\n- Readiness requires zero formatting issues, linter warnings, or failing tests.\n\n## GitHub and CI Practices\n- Treat GitHub workflows as first-class code: keep them under version control, review every change, and follow `.github/AGENTS.md` for directory-specific rules.\n- Pipeline secrets reside in the `prod` environment.\n- Interact with pipelines locally using [WRKFLW](https://github.com/bahdotsh/wrkflw) to validate and run workflows when needed.\n- Use the GitHub interface to inspect logs from the five most recent pipeline runs.\n- Prefer the [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) pipelines for Rust projects—they are our required standard.\n- After completing a task, verify that the current branch's HEAD matches `origin/main`; if `origin/main` has advanced, restart the task from the latest commit.\n\n## Instruction Management\n- This root `AGENTS.md` is fetched from a remote server during container initialization. Update it only when you intentionally change the global rules.\n- Repository-specific instructions may appear in `REPO_AGENTS.md`. If this file is absent, assume no extra instructions.\n- Additional `AGENTS.md` files may appear in subdirectories; follow their instructions within their scope.\n- Keep `AGENTS.md` entries in English.\n\n## Communication\n- Replies to users must be concise and in **Russian**.\n- Source code, comments, documentation, branch names, and commit messages must be in **English**.\n- If a task description is in Russian, translate branch and task names into English.\n- Describe the environment as a production workspace; never call it a training or sandbox setting.\n- Keep pull requests concise: list changes, reference lines with `F:path#Lx-Ly`, and attach test results.\n- In the final summary, list all avatars used and provide the link to the open pull request together with the status of every mandatory check.\n\n## Documentation\n- Markdown uses `#` for headers and specifies languages for code blocks.\n- Markdown filenames must be ALL_CAPS with underscores between words.\n- Comments and documentation are always in English.\n\n## Reasoning\n- Apply JointThinking to every user request:\n  - Produce a quick answer (*Nothinking*) and a deliberate answer (*Thinking*).\n  - If both answers match, return the *Thinking* version.\n  - If they differ, analyse both and output a revised *Thinking* response.\n- Formatting example:\n  ```\n  [Nothinking] fast answer\n  [Thinking] detailed answer\n\n  [Thinking:revision] refined answer\n  ```\n",
   "avatars": [
     {
-      "id": "tester",
-      "name": "Automated Test Engineer",
-      "description": "Designs and executes automated test cases to find defects.",
+      "id": "analyst",
+      "name": "Business Analyst",
+      "description": "Translates business requirements into actionable tasks.",
       "tags": [
-        "testing",
-        "qa"
+        "analysis",
+        "requirements"
       ],
       "author": "QQRM",
       "created_at": "2025-08-02",
       "version": "0.1",
-      "uri": "avatars/TESTER.md"
-    },
-    {
-      "id": "devops_maintainer",
-      "name": "DevOps Engineer",
-      "description": "Maintains reproducible CI/CD pipelines and optimizes automation.",
-      "tags": [
-        "devops",
-        "ci",
-        "automation"
-      ],
-      "author": "QQRM",
-      "created_at": "2025-08-02",
-      "version": "0.1",
-      "uri": "avatars/DEVOPS.md"
+      "uri": "avatars/ANALYST.md"
     },
     {
       "id": "architect",
@@ -43,6 +30,33 @@
       "uri": "avatars/ARCHITECT.md"
     },
     {
+      "id": "devops_maintainer",
+      "name": "DevOps Engineer",
+      "description": "Maintains reproducible CI/CD pipelines and optimizes automation.",
+      "tags": [
+        "devops",
+        "ci",
+        "automation"
+      ],
+      "author": "QQRM",
+      "created_at": "2025-08-02",
+      "version": "0.1",
+      "uri": "avatars/DEVOPS.md"
+    },
+    {
+      "id": "security",
+      "name": "Security Engineer",
+      "description": "Ensures code and pipelines are secure from attacks.",
+      "tags": [
+        "security",
+        "auditing"
+      ],
+      "author": "QQRM",
+      "created_at": "2025-08-02",
+      "version": "0.1",
+      "uri": "avatars/SECURITY.md"
+    },
+    {
       "id": "senior_developer",
       "name": "Senior Rust Developer",
       "description": "Seasoned Rust developer delivering reliable, high-performance features.",
@@ -55,19 +69,6 @@
       "created_at": "2025-08-13",
       "version": "0.1",
       "uri": "avatars/DEVELOPER.md"
-    },
-    {
-      "id": "analyst",
-      "name": "Business Analyst",
-      "description": "Translates business requirements into actionable tasks.",
-      "tags": [
-        "analysis",
-        "requirements"
-      ],
-      "author": "QQRM",
-      "created_at": "2025-08-02",
-      "version": "0.1",
-      "uri": "avatars/ANALYST.md"
     },
     {
       "id": "tech_lead",
@@ -84,17 +85,17 @@
       "uri": "avatars/TECH_LEAD.md"
     },
     {
-      "id": "security",
-      "name": "Security Engineer",
-      "description": "Ensures code and pipelines are secure from attacks.",
+      "id": "tester",
+      "name": "Automated Test Engineer",
+      "description": "Designs and executes automated test cases to find defects.",
       "tags": [
-        "security",
-        "auditing"
+        "testing",
+        "qa"
       ],
       "author": "QQRM",
       "created_at": "2025-08-02",
       "version": "0.1",
-      "uri": "avatars/SECURITY.md"
+      "uri": "avatars/TESTER.md"
     }
   ]
 }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "avatars-cli"
+version = "0.1.0"
+edition = "2024"
+default-run = "avatars-cli"
+
+[dependencies]
+avatars-core = { path = "../core" }
+serde_json = "1.0"

--- a/crates/cli/src/bin/index_uris.rs
+++ b/crates/cli/src/bin/index_uris.rs
@@ -1,4 +1,4 @@
-use avatars_generator::Index;
+use avatars_core::Index;
 use std::env;
 use std::error::Error;
 use std::fs;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,10 +1,14 @@
-use avatars_generator::generate_index;
+use avatars_core::generate_index;
 use std::path::Path;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let avatars_dir = Path::new("avatars");
     let base_path = Path::new("AGENTS.md");
     let index = generate_index(avatars_dir, base_path)?;
-    println!("Index generated with {} avatars", index.avatars.len());
+    println!(
+        "Index generated with {} avatars (base instructions at {})",
+        index.avatars.len(),
+        index.base_uri
+    );
     Ok(())
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "avatars-core"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.9"
+serde_json = "1.0"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "avatars-mcp"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde_json = "1.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util"] }


### PR DESCRIPTION
## Summary
- extract the generator into a new `avatars-core` library with deterministic sorting and embedded `base_instructions`, and move the binaries into dedicated `avatars-cli` and `avatars-mcp` crates
- expand the MCP server so it lists and serves `AGENTS.md` and avatar Markdown files while resolving paths relative to the workspace root
- refresh documentation to describe the workspace layout and explicitly document the `AGENTS.md` REST endpoint

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

## Avatar
- Software Architect — provides the architectural perspective needed to split the monolithic crate into focused workspace members while tightening interface guarantees


------
https://chatgpt.com/codex/tasks/task_e_68cc1259149c8332b2b00b7c2e49be52