### PR TITLE
Split container initialization and pre-task workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,9 @@ These guidelines apply to every avatar in this repository.
 - Prefer command-line tooling and automate repetitive steps to keep workflows reproducible.
 - Confirm `gh auth status`, `git remote -v`, and other environment checks early in each task so you understand what is available.
 - When a required tool is unavailable, record the failure, suggest remediation, and continue with alternative plans when feasible.
-- Keep repository automation in `repo-setup.sh` and author helpers in POSIX shell. The shared `setup.sh` bootstrapper runs `repo-setup.sh` automatically.
+- Keep repository automation in `repo-setup.sh` and author helpers in POSIX shell. Run `init-container.sh` once per container to install global tooling, and invoke `pre-task.sh` before every assignment so it refreshes shared assets and executes `repo-setup.sh` when available.
 - If a `local_setup.sh` script exists, execute it before starting any task.
-- `setup.sh` installs the `crates-mcp` server via `cargo-binstall` with a source fallback, and `mcp.json` enables it by default.
+- `init-container.sh` installs the `crates-mcp` server via `cargo-binstall` with a source fallback, and `mcp.json` enables it by default.
 - Available local MCP servers include `crates-mcp` (e.g., `{ "tool": "search_crates", "query": "http client" }`).
 
 ## Source Control and Branching

--- a/README.md
+++ b/README.md
@@ -17,7 +17,17 @@ git remote add origin https://github.com/qqrm/avatars-mcp.git
 git fetch origin
 ```
 
-Run `./setup.sh` to install the optional MCP servers referenced by `mcp.json`; it automatically invokes a repository-specific `repo-setup.sh` when present.
+Initialize a fresh container once:
+
+```bash
+curl -fsSL "https://raw.githubusercontent.com/qqrm/avatars-mcp/refs/heads/main/init-container.sh" | bash -s --
+```
+
+Before starting each task, refresh the workspace:
+
+```bash
+curl -fsSL "https://raw.githubusercontent.com/qqrm/avatars-mcp/refs/heads/main/pre-task.sh" | bash -s --
+```
 
 ## Documentation
 
@@ -36,11 +46,12 @@ External clients rely on a small set of shared files published alongside the ava
 
 Repository tooling keeps these artifacts in sync for local use:
 
-- [`setup.sh`](setup.sh) — a POSIX shell bootstrapper that installs tooling while mirroring the published baseline instructions and avatar index.
+- [`init-container.sh`](init-container.sh) — installs the required tooling and persists GitHub CLI authentication for the container.
+- [`pre-task.sh`](pre-task.sh) — refreshes the MCP assets and executes repository-specific setup helpers before each task.
 
 ## Repository-Specific Setup Script
 
-Every repository in this ecosystem can ship its own local setup helper tailored to its automation requirements under the shared name `repo-setup.sh`. The [`setup.sh`](setup.sh) script in this repository provisions GitHub CLI authentication, installs required Rust tooling, refreshes the published MCP assets directly, and then runs `repo-setup.sh` if it exists. When working in other repositories, expect their `repo-setup.sh` contents to diverge—each project documents and automates only the dependencies it needs while keeping the filename consistent.
+Every repository in this ecosystem can ship its own local setup helper tailored to its automation requirements under the shared name `repo-setup.sh`. The [`init-container.sh`](init-container.sh) script runs once to provision GitHub CLI authentication and install the Rust tooling used across tasks. The [`pre-task.sh`](pre-task.sh) helper reruns before each assignment to refresh the published MCP assets and invoke `repo-setup.sh` when present. When working in other repositories, expect their `repo-setup.sh` contents to diverge—each project documents and automates only the dependencies it needs while keeping the filename consistent.
 
 ## Tooling
 

--- a/pre-task.sh
+++ b/pre-task.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# pre-task.sh
+# Refresh dynamic repository assets before starting a new task.
+
+set -Eeuo pipefail
+trap 'rc=$?; echo -e "\n!! pre-task failed at line $LINENO while running: $BASH_COMMAND (exit $rc)" >&2; exit $rc' ERR
+
+SCRIPT_PATH="${BASH_SOURCE[0]-}"
+SCRIPT_SOURCE_IS_STDIN=0
+if [[ -n "$SCRIPT_PATH" && "$SCRIPT_PATH" != "-" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+  cd "$SCRIPT_DIR"
+else
+  SCRIPT_DIR="$(pwd)"
+  SCRIPT_SOURCE_IS_STDIN=1
+fi
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "pre-task: must run inside a Git repository" >&2
+  exit 1
+fi
+
+log() { printf '>> %s\n' "$*"; }
+
+MCP_BASE_URL="${MCP_BASE_URL:-https://qqrm.github.io/avatars-mcp}"
+AGENTS_URL="${MCP_BASE_URL%/}/AGENTS.md"
+MCP_MANIFEST_URL="${MCP_BASE_URL%/}/mcp.json"
+
+fetch_file() {
+  local url="$1"
+  local dest="$2"
+  local tmp
+  tmp="${dest}.tmp"
+  if curl -fsSL "$url" -o "$tmp"; then
+    mv "$tmp" "$dest"
+    log "Updated $(basename "$dest") from $url"
+  else
+    rm -f "$tmp"
+    log "Unable to refresh $(basename "$dest") from $url"
+  fi
+}
+
+fetch_file "$AGENTS_URL" "AGENTS.md"
+fetch_file "$MCP_MANIFEST_URL" "mcp.json"
+
+if [ -f repo-setup.sh ]; then
+  log "Executing repo-setup.sh"
+  bash repo-setup.sh
+fi
+
+log "Pre-task refresh complete."


### PR DESCRIPTION
## Summary
- add an `init-container.sh` entrypoint for one-time tooling installation and persist GitHub CLI authentication, removing the old `setup.sh`
- introduce `pre-task.sh` to refresh `AGENTS.md`/`mcp.json` and execute `repo-setup.sh` before each assignment
- update repository instructions to document the new scripts and curl entrypoints

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68cdecf0254c8332b97a4cb49c5a38f4