### PR TITLE
Clarify CLI usage and extend agent sync automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ Every repository in this ecosystem can ship its own local setup helper tailored 
 
 ## Tooling
 
-A Rust workspace under [`/crates/`](crates/) regenerates the catalog stored at [`avatars/catalog.json`](avatars/catalog.json) by parsing the avatar front matter and bundling both the base instructions and avatar metadata. The GitHub Pages deployment exposes this catalog as `avatars.json`. The deployment pipeline rebuilds the index automatically whenever `main` changes, so running the generator locally is only necessary for debugging or previewing changes. Build the index with:
+A Rust workspace under [`/crates/`](crates/) regenerates the catalog stored at [`avatars/catalog.json`](avatars/catalog.json) by parsing the avatar front matter and bundling both the base instructions and avatar metadata. The GitHub Pages deployment exposes this catalog as `avatars.json`. The deployment pipeline rebuilds the index automatically whenever `main` changes, so running the generator locally is only necessary for debugging or previewing changes. Build the index with either form below:
 
 ```bash
 cargo run -p avatars-cli --release
 ```
+
+The workspace sets `default-run = "avatars-cli"`, so the deployment pipeline invokes the same binary with `cargo run --release`.
 
 The auxiliary binary `index_uris` (packaged with the CLI crate) lists the avatar URIs from an existing catalog to simplify pipeline scripting. Clients begin with `avatars.json` to decide which personas they need, then fetch `AGENTS.md` and the target avatars on demand to avoid loading unnecessary Markdown into the working context.
 

--- a/REPO_AGENTS.md
+++ b/REPO_AGENTS.md
@@ -6,7 +6,7 @@ These instructions extend the base `AGENTS.md` rules for the entire repository.
 - Confirm `git remote -v` and `gh auth status` before making changes; Codex bootstrap scripts already configure the workspace.
 - Leave the bootstrap `work` branch immediately, create a descriptive feature branch, and avoid any branch named `WORK`.
 - Follow the global Source Control checklist: clean up stale remote branches with `gh`, close any linked pull requests, and reproduce the repository's required workflows locally with `wrkflw` before reporting completion.
-- Treat the GitHub Pages deployment as the source of truth for `avatars.json`: it rebuilds the catalog automatically whenever `main` is published. Run `cargo run -p avatars-cli --release` only when you need a local preview or to debug generator failures, and avoid committing derived `avatars/catalog.json` output unless the task explicitly changes the generator.
+- Treat the GitHub Pages deployment as the source of truth for `avatars.json`: it rebuilds the catalog automatically whenever `main` is published. Run `cargo run -p avatars-cli --release` (or rely on the workspace default with `cargo run --release`) only when you need a local preview or to debug generator failures, and avoid committing derived `avatars/catalog.json` output unless the task explicitly changes the generator.
 
 ## Environment Checks
 - If `git remote -v` or `gh auth status` show problems, capture the full command output, diagnose the cause, and propose a fix or workaround.

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -118,7 +118,7 @@ The optional Model Context Protocol server mirrors these resources over STDIO an
 
 - Add new avatars by committing additional Markdown files under `/avatars/` with the required front matter.
 - Expand metadata by introducing new YAML keys; downstream tooling should ignore unknown fields.
-- The Rust workspace under `crates/` can regenerate `avatars/catalog.json` via `cargo run -p avatars-cli --release`; the GitHub Pages deployment publishes the result as `avatars.json`.
+- The Rust workspace under `crates/` can regenerate `avatars/catalog.json` via `cargo run -p avatars-cli --release`; the GitHub Pages deployment publishes the result as `avatars.json`. The workspace sets `default-run = "avatars-cli"`, so `cargo run --release` resolves to the same binary in automation contexts.
 
 ## 7. Relationship to README
 

--- a/scripts/SPECIFICATION.md
+++ b/scripts/SPECIFICATION.md
@@ -1,0 +1,18 @@
+# Scripts Specification
+
+## `agent-sync.sh`
+
+The `agent-sync.sh` helper keeps a feature branch synchronized with `origin/main` inside constrained automation environments.
+Run it from the repository root after staging local work and before handing the branch back to maintainers.
+
+The script performs the following steps:
+
+1. Verifies it is running inside a Git repository and refuses to operate on `main` directly.
+2. Detects the target branch from `TASK_BRANCH` or the current `HEAD` and fetches the latest `origin/main` revision.
+3. Attempts a `git rebase origin/main` and falls back to `git merge --no-ff origin/main` if the rebase fails.
+4. Regenerates `Cargo.lock` when conflicts arise, invoking `cargo generate-lockfile` to ensure reproducible dependency graphs.
+5. Recreates derived artifacts through `scripts/gen.sh` when that generator is present and executable.
+6. Runs the repository validation pipeline: `cargo fmt --all`, `cargo generate-lockfile`, `cargo check --tests --benches`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo machete` (when available).
+7. Records pending changes in `.agent_status` so automation can detect when manual follow-up is required.
+
+Use this helper whenever a task requires syncing with upstream without manually invoking each command, especially in environments where interactive rebases are restricted. The script exits on the first failure to preserve a clean state for further investigation.

--- a/scripts/agent-sync.sh
+++ b/scripts/agent-sync.sh
@@ -45,8 +45,18 @@ cargo generate-lockfile
 echo "[agent-sync] Running cargo check"
 cargo check --tests --benches
 
+echo "[agent-sync] Running cargo clippy"
+cargo clippy --all-targets --all-features -- -D warnings
+
 echo "[agent-sync] Running cargo test"
 cargo test
+
+if command -v cargo-machete >/dev/null 2>&1; then
+  echo "[agent-sync] Running cargo machete"
+  cargo machete
+else
+  echo "[agent-sync] Skipping cargo machete (cargo-machete not installed)"
+fi
 
 if git status --porcelain | grep -q .; then
   echo "SYNC_PENDING_CHANGES=1" > "${STATUS_FILE}"


### PR DESCRIPTION
## Summary
- document both supported cargo run commands in README, SPECIFICATION, and repository agent guidance
- add a scripts/SPECIFICATION.md index describing agent-sync responsibilities
- extend scripts/agent-sync.sh to run clippy and machete with graceful detection of the latter

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- wrkflw run .github/workflows/ci.yml
- wrkflw run .github/workflows/pages.yml *(fails in emulation: shell syntax for loops and arrays)*

------
https://chatgpt.com/codex/tasks/task_e_68ce1c5412b08332bf5d01942fe07c58