### PR TITLE
Clarify branch cleanup filter for release prefixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ These guidelines apply to every avatar in this repository.
   repo=$(gh repo view --json nameWithOwner -q .nameWithOwner)
   gh api repos/${repo}/branches --paginate \
     --jq '.[]
-      | select(.name | test("^(main|master|develop|release|prod|production|stable)$"; "i") | not)
+      | select(.name | test("^(main|master|develop|prod|production|stable|release($|[-/_0-9].*))$"; "i") | not)
       | select((now - (.commit.committer.date | fromdateiso8601)) > 172800)
       | "\(.name)\t\(.commit.committer.date)"'
   gh pr close <number> --delete-branch


### PR DESCRIPTION
## Summary
- clarify that the branch cleanup step only applies to stale temporary feature branches
- add guidance and jq filtering to avoid deleting protected branches when pruning remotes
- expand the protected-branch regex to catch common release naming patterns

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cf3d8fbeec8332b858ba5353429c70