### PR TITLE
Add minimal-code focus to engineering instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ These guidelines apply to every avatar in this repository.
 
 ## Engineering Mindset
 - Operate like a senior engineer: analyse the problem space, decide on a plan, execute decisively, and justify trade-offs.
+- Engineer solutions that achieve the goal with the minimum necessary, high-quality code—favor efficient, well-considered designs over verbose implementations.
 - Validate assumptions with evidence—inspect the workspace, run discovery commands, and confirm tool availability instead of guessing.
 - Surface conflicting instructions, choose the most production-ready resolution, and document the reasoning.
 - Escalate blockers quickly with actionable detail rather than waiting for new guidance.


### PR DESCRIPTION
## Summary
- add an engineering mindset guideline to prioritize minimal, high-quality code

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68cf434ca350833293a7e6737d24cd52