### PR TITLE
Remove GraphQL from Markdown auto-merge workflow

### DIFF
--- a/.github/workflows/markdown-automerge.yml
+++ b/.github/workflows/markdown-automerge.yml
@@ -1,0 +1,58 @@
+# Repository-level auto-merge must remain enabled and required checks must succeed before GitHub finishes the merge.
+name: Markdown Auto Merge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+
+permissions:
+  contents: write
+
+concurrency:
+  group: markdown-automerge-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  markdown-automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inspect pull request files
+        id: validate_files
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.pull_request.number;
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number, per_page: 100 }
+            );
+            const nonMarkdown = files
+              .filter((file) => !file.filename.toLowerCase().endsWith('.md'))
+              .map((file) => file.filename);
+            if (nonMarkdown.length > 0) {
+              core.info(`Non-Markdown files detected: ${nonMarkdown.join(', ')}`);
+              core.setOutput('all_markdown', 'false');
+              return;
+            }
+            core.info(`All ${files.length} file(s) are Markdown.`);
+            core.setOutput('all_markdown', 'true');
+      # Auto-merge must remain enabled at the repository level.
+      # GitHub still waits for every required check before completing the merge.
+      - name: Enable auto-merge for Markdown-only pull requests
+        if: steps.validate_files.outputs.all_markdown == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge "$PR_URL" --auto --squash
+      - name: Skip auto-merge
+        if: steps.validate_files.outputs.all_markdown != 'true'
+        run: echo "Auto-merge disabled because non-Markdown files were detected."


### PR DESCRIPTION
## Summary
- refactor the markdown auto-merge workflow created in the previous iteration
- verify pull request files remain Markdown-only before proceeding
- enable auto-merge with the GitHub CLI instead of the GraphQL mutation and document repository-level prerequisites

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- wrkflw validate
- wrkflw run .github/workflows/markdown-automerge.yml *(fails locally: GH_TOKEN not authorized in emulated runner)*

------
https://chatgpt.com/codex/tasks/task_e_68cf52c7e2248332a181ce4e0db8cf37