### PR TITLE
Remove GraphQL from Markdown auto-merge workflow

### DIFF
--- a/.github/workflows/markdown-automerge.yml
+++ b/.github/workflows/markdown-automerge.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: markdown-automerge-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
- refactor the markdown auto-merge workflow created in the previous iteration
- verify pull request files remain Markdown-only before proceeding
- enable auto-merge with the GitHub CLI instead of the GraphQL mutation and document repository-level prerequisites
- grant the workflow `pull-requests: write` permission so `gh pr merge` can enable auto-merge

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- wrkflw validate
- wrkflw run .github/workflows/markdown-automerge.yml *(fails locally: GH_TOKEN not authorized in emulated runner)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6c5a80b48332bdea828a3de087f1