### PR TITLE
Move Codex cleanup bootstrap to init container

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -5,6 +5,7 @@ These rules apply to everything under `.github`.
 ## Workflow Authoring
 - Place GitHub workflow definitions inside `.github/workflows` using lowercase hyphen-case filenames that end with `.yml`.
 - Give each workflow a descriptive Title Case `name` so runs are easy to identify.
+- Use the exact workflow title `Codex Branch Cleanup` for the scheduled Codex branch pruning pipeline so cross-repository automation can recognise it consistently.
 - Keep triggers minimal: default to `push`/`pull_request` on `main` and add extra events only when the feature requires them.
 - Name jobs in lowercase with hyphenated identifiers (for example, `build`, `deploy`) and prefer a single responsibility per job.
 

--- a/.github/workflows/codex-cleanup.yml
+++ b/.github/workflows/codex-cleanup.yml
@@ -1,0 +1,190 @@
+name: Codex Branch Cleanup
+
+on:
+  schedule:
+    - cron: '0 */12 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: codex-branch-cleanup-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cleanup:
+    name: cleanup
+    runs-on: ubuntu-latest
+    steps:
+      - name: prune codex branches and pull requests
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const core = require('@actions/core');
+            const cutoffMs = 24 * 60 * 60 * 1000;
+            const now = Date.now();
+            const branchPrefix = 'codex/';
+            const codexAuthor = 'github-codex[bot]';
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const repoInfo = await github.rest.repos.get({ owner, repo });
+            const defaultBranch = repoInfo.data.default_branch;
+            const protectedBranches = new Set([
+              defaultBranch,
+              'main',
+              'master',
+              'develop',
+              'production',
+              'prod',
+            ]);
+
+            const processedBranches = new Set();
+            const deletedBranches = [];
+            const skippedBranches = [];
+            const closedPulls = [];
+
+            core.info(`Repository default branch: ${defaultBranch}`);
+            core.info(`Evaluating branches with prefix "${branchPrefix}" older than ${cutoffMs / 3600000} hours.`);
+
+            const listBranches = await github.paginate(
+              github.rest.repos.listBranches,
+              { owner, repo, per_page: 100 }
+            );
+
+            function parseCommitDate(branch) {
+              const commit = branch?.commit?.commit;
+              return (
+                commit?.committer?.date ||
+                commit?.author?.date ||
+                null
+              );
+            }
+
+            async function deleteBranch(ref, reason) {
+              if (!ref) {
+                core.warning(`Skipping branch deletion: empty ref encountered (${reason}).`);
+                return false;
+              }
+
+              if (processedBranches.has(ref)) {
+                core.info(`Branch ${ref} already processed (${reason}).`);
+                return false;
+              }
+
+              if (!ref.startsWith(branchPrefix)) {
+                core.info(`Skipping branch ${ref}: does not match prefix ${branchPrefix}.`);
+                skippedBranches.push({ ref, reason: 'prefix-mismatch' });
+                processedBranches.add(ref);
+                return false;
+              }
+
+              if (protectedBranches.has(ref)) {
+                core.warning(`Refusing to delete protected branch ${ref} (${reason}).`);
+                skippedBranches.push({ ref, reason: 'protected' });
+                processedBranches.add(ref);
+                return false;
+              }
+
+              try {
+                await github.rest.git.deleteRef({ owner, repo, ref: `heads/${ref}` });
+                core.info(`Deleted branch ${ref} (${reason}).`);
+                deletedBranches.push(ref);
+                processedBranches.add(ref);
+                return true;
+              } catch (error) {
+                if (error.status === 404) {
+                  core.info(`Branch ${ref} already removed (${reason}).`);
+                } else {
+                  core.warning(`Failed to delete branch ${ref} (${reason}): ${error.message}`);
+                }
+                skippedBranches.push({ ref, reason: 'delete-failed', error: error.message });
+                processedBranches.add(ref);
+                return false;
+              }
+            }
+
+            for (const branch of listBranches) {
+              const name = branch.name;
+              const commitDateIso = parseCommitDate(branch);
+              if (!name.startsWith(branchPrefix)) {
+                continue;
+              }
+
+              if (protectedBranches.has(name)) {
+                core.info(`Skipping branch ${name}: protected name.`);
+                continue;
+              }
+
+              if (!commitDateIso) {
+                core.warning(`Skipping branch ${name}: unable to determine commit timestamp.`);
+                skippedBranches.push({ ref: name, reason: 'no-commit-timestamp' });
+                continue;
+              }
+
+              const commitTime = Date.parse(commitDateIso);
+              if (Number.isNaN(commitTime)) {
+                core.warning(`Skipping branch ${name}: invalid commit timestamp ${commitDateIso}.`);
+                skippedBranches.push({ ref: name, reason: 'invalid-timestamp' });
+                continue;
+              }
+
+              const ageMs = now - commitTime;
+              if (ageMs <= cutoffMs) {
+                core.info(`Branch ${name} age ${Math.round(ageMs / 3600000)}h is within retention.`);
+                continue;
+              }
+
+              await deleteBranch(name, `stale (${Math.round(ageMs / 3600000)}h old)`);
+            }
+
+            const pulls = await github.paginate(
+              github.rest.pulls.list,
+              { owner, repo, state: 'open', per_page: 100 }
+            );
+
+            for (const pr of pulls) {
+              if (pr.user?.login !== codexAuthor) {
+                continue;
+              }
+
+              const created = Date.parse(pr.created_at);
+              if (!Number.isFinite(created)) {
+                core.warning(`Skipping PR #${pr.number}: invalid created_at ${pr.created_at}.`);
+                continue;
+              }
+
+              const ageMs = now - created;
+              if (ageMs <= cutoffMs) {
+                core.info(`PR #${pr.number} is ${Math.round(ageMs / 3600000)}h old; within retention.`);
+                continue;
+              }
+
+              core.info(`Closing PR #${pr.number} (${pr.title}) opened by ${codexAuthor}; age ${Math.round(ageMs / 3600000)}h.`);
+              try {
+                await github.rest.pulls.update({ owner, repo, pull_number: pr.number, state: 'closed' });
+                closedPulls.push(pr.number);
+              } catch (error) {
+                core.warning(`Failed to close PR #${pr.number}: ${error.message}`);
+                continue;
+              }
+
+              const headRef = pr.head?.ref;
+              await deleteBranch(headRef, `closed PR #${pr.number}`);
+            }
+
+            core.info(`Codex cleanup summary:`);
+            core.info(`  Deleted branches: ${deletedBranches.join(', ') || 'none'}`);
+            core.info(`  Closed pull requests: ${closedPulls.join(', ') || 'none'}`);
+            if (skippedBranches.length > 0) {
+              for (const entry of skippedBranches) {
+                core.info(`  Skipped ${entry.ref}: ${entry.reason}${entry.error ? ` (${entry.error})` : ''}`);
+              }
+            }

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,6 +33,8 @@ jobs:
           mkdir -p public/avatars
           cp -r avatars/* public/avatars/
           cp AGENTS.md INSTRUCTIONS.md README.md mcp.json public/
+          mkdir -p public/workflows
+          cp .github/workflows/codex-cleanup.yml public/workflows/
           cp avatars/catalog.json public/index.json
           cp avatars/catalog.json public/avatars.json
           {
@@ -77,6 +79,7 @@ jobs:
             "INSTRUCTIONS.md"
             "README.md"
             "mcp.json"
+            "workflows/codex-cleanup.yml"
           )
           sleep 10
           for path in "${paths[@]}"; do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ These guidelines apply to every avatar in this repository.
 
 ## GitHub and CI Practices
 - Treat GitHub workflows as first-class code: keep them under version control, review every change, and follow `.github/AGENTS.md` for directory-specific rules.
+- Every repository maintained through Codex must carry the `Codex Branch Cleanup` workflow at `.github/workflows/codex-cleanup.yml`. Keep the workflow name unchanged, preserve the schedule/dispatch triggers, and align its implementation with the canonical version in this repository. The container bootstrap (`./init-container.sh`) automatically installs the workflow from our GitHub Pages mirror when it is missing.
 - Pipeline secrets reside in the `prod` environment.
 - Run GitHub Actions workflows locally with [WRKFLW](https://github.com/bahdotsh/wrkflw) before handing off a branch. Typical commands:
   ```bash


### PR DESCRIPTION
## Summary
- keep the Codex Branch Cleanup workflow published via GitHub Pages and add a smoke test for its mirror
- bootstrap the canonical cleanup workflow once during container initialization instead of the per-task refresh
- document the init-container bootstrap requirement and simplify pre-task updates accordingly

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68cf90fc2c708332aa8cd0dd445d036a