### PR TITLE
Remove push branch requirements from instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,6 @@ These guidelines apply to every avatar in this repository.
 ## Source Control and Branching
 - Treat the canonical `origin` remote as writable until a push attempt proves otherwise; do not assume restrictions without evidence.
 - Create a fresh hyphenated English feature branch for every task. When a task spans multiple sessions, stay on the same branch, fetch `origin/main`, and rebase or merge **before every response**.
-- Keep the task branch alive until maintainers confirm integration—never delete, rename, or reset it mid-task, and push every new commit to the same remote branch.
-- After preparing commits, push the branch to `origin` (for example, `git push --set-upstream origin <branch>`). Escalate immediately if the push fails.
 - Before reporting completion, confirm that `origin/<branch>` contains the latest commits (compare with `git log HEAD`).
 - When a push or GitHub command fails, quote the full stderr/stdout, diagnose the cause, and propose mitigation steps instead of stopping at the first error.
 - Maintain small, focused commits with clear English messages so reviewers can follow each step.

--- a/REPO_AGENTS.md
+++ b/REPO_AGENTS.md
@@ -12,4 +12,3 @@ These instructions extend the base `AGENTS.md` rules for the entire repository.
 - If `git remote -v` or `gh auth status` show problems, capture the full command output, diagnose the cause, and propose a fix or workaround.
 
 ## Branch Management and Handoff
-This repository follows the global branching guidance in `AGENTS.md`. Push every commit to the same feature branch, reproduce the required checks locally, and hand the branch to maintainers so they can open the pull request manually via Codex.


### PR DESCRIPTION
## Summary
- remove global guidance that required pushing feature branches to the remote
- drop repository-specific reminder to push every commit to the feature branch

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68d5125e4124833296c16f91a828c5cf